### PR TITLE
[feat/sidebar-sub] - 사이드바 서브 메뉴 연결

### DIFF
--- a/src/app/(main)/goal/[goalId]/note/create/page.tsx
+++ b/src/app/(main)/goal/[goalId]/note/create/page.tsx
@@ -10,9 +10,7 @@ export default async function Page({
   searchParams: Promise<{ todoId?: string }>;
 }) {
   const { goalId } = await params;
-  // const { todoId } = await searchParams;
-  // @TODO 13번 줄 주석 풀고 15번 줄 주석
-  const todoId = 8;
+  const { todoId } = await searchParams;
 
   const [goal, todo] = await Promise.all([
     fetchGoals.getGoal(Number(goalId)),
@@ -21,4 +19,3 @@ export default async function Page({
 
   return <NoteCreateClient goal={goal} todo={todo} />;
 }
-

--- a/src/contexts/SidebarContext.tsx
+++ b/src/contexts/SidebarContext.tsx
@@ -57,11 +57,11 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
         name: '할 일',
         href: '/dashboard/all-todo',
       },
-      {
-        icon: <CalendarDaysIcon />,
-        name: '캘린더',
-        href: '/calendar',
-      },
+      // {
+      //   icon: <CalendarDaysIcon />,
+      //   name: '캘린더',
+      //   href: '/calendar',
+      // },
       // TODO: 소통게시판, 찜한 할일은 중간 이후에 활성화
       // {
       //   icon: <MessageSquareIcon />,

--- a/src/contexts/SidebarContext.tsx
+++ b/src/contexts/SidebarContext.tsx
@@ -1,11 +1,13 @@
 'use client';
 
+import { useQuery } from '@tanstack/react-query';
 import { usePathname } from 'next/navigation';
 import { createContext, useContext, useState, ReactNode, useMemo } from 'react';
-import { LayoutGridIcon, FlagIcon, CalendarDaysIcon, MessageSquareIcon, StarIcon } from 'lucide-react';
+import { LayoutGridIcon, FlagIcon, CalendarDaysIcon, ListCheckIcon, MessageSquareIcon, StarIcon } from 'lucide-react';
 
+import { goalQueries } from '@/lib/queryKeys';
 interface MenuBase {
-  icon: React.ReactNode;
+  icon?: React.ReactNode;
   name: string;
 }
 interface LeafMenu extends MenuBase {
@@ -16,7 +18,7 @@ interface ParentMenu extends MenuBase {
   href: string;
   subMenus: MenuItem[];
 }
-type MenuItem = LeafMenu | ParentMenu;
+export type MenuItem = LeafMenu | ParentMenu;
 
 interface SidebarContextType {
   toggle: () => void;
@@ -33,6 +35,8 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(true);
   const pathname = usePathname();
 
+  const { data: goal } = useQuery(goalQueries.list());
+  console.log('goal: ', goal);
   // TODO: 서브메뉴 목표랑 연결하도록 구현 필요
   const allMenus = useMemo<MenuItem[]>(() => {
     return [
@@ -45,22 +49,35 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
         icon: <FlagIcon />,
         name: '목표',
         href: '/goal',
+        // subMenus: [
+        //   {
+        //     name: `${goal?.goalName ?? '목표 없음'}`,
+        //     href: '/goal/[id]',
+        //     match: `/goal/${goal?.id}`,
+        //   },
+        // ],
+      },
+      {
+        icon: <ListCheckIcon />,
+        name: '할 일',
+        href: '/dashboard/all-todo',
       },
       {
         icon: <CalendarDaysIcon />,
         name: '캘린더',
         href: '/calendar',
       },
-      {
-        icon: <MessageSquareIcon />,
-        name: '소통게시판',
-        href: '/community',
-      },
-      {
-        icon: <StarIcon />,
-        name: '찜한 할일',
-        href: '/favorite-todo',
-      },
+      // TODO: 소통게시판, 찜한 할일은 중간 이후에 활성화
+      // {
+      //   icon: <MessageSquareIcon />,
+      //   name: '소통게시판',
+      //   href: '/community',
+      // },
+      // {
+      //   icon: <StarIcon />,
+      //   name: '찜한 할일',
+      //   href: '/favorite-todo',
+      // },
     ];
   }, []);
 

--- a/src/contexts/SidebarContext.tsx
+++ b/src/contexts/SidebarContext.tsx
@@ -3,22 +3,20 @@
 import { useQuery } from '@tanstack/react-query';
 import { usePathname } from 'next/navigation';
 import { createContext, useContext, useState, ReactNode, useMemo } from 'react';
-import { LayoutGridIcon, FlagIcon, CalendarDaysIcon, ListCheckIcon, MessageSquareIcon, StarIcon } from 'lucide-react';
+import { LayoutGridIcon, FlagIcon, CalendarDaysIcon, ListCheckIcon } from 'lucide-react';
 
 import { goalQueries } from '@/lib/queryKeys';
 interface MenuBase {
   icon?: React.ReactNode;
   name: string;
 }
-interface LeafMenu extends MenuBase {
+interface SubMenu extends MenuBase {
   href: string;
-  subMenus?: string[];
 }
-interface ParentMenu extends MenuBase {
+export interface MenuItem extends MenuBase {
   href: string;
-  subMenus: MenuItem[];
+  subMenus?: SubMenu[];
 }
-export type MenuItem = LeafMenu | ParentMenu;
 
 interface SidebarContextType {
   toggle: () => void;
@@ -36,8 +34,8 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
   const pathname = usePathname();
 
   const { data: goal } = useQuery(goalQueries.list());
-  console.log('goal: ', goal);
-  // TODO: 서브메뉴 목표랑 연결하도록 구현 필요
+  const goalData = useMemo(() => goal?.goals ?? [], [goal]);
+
   const allMenus = useMemo<MenuItem[]>(() => {
     return [
       {
@@ -49,13 +47,10 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
         icon: <FlagIcon />,
         name: '목표',
         href: '/goal',
-        // subMenus: [
-        //   {
-        //     name: `${goal?.goalName ?? '목표 없음'}`,
-        //     href: '/goal/[id]',
-        //     match: `/goal/${goal?.id}`,
-        //   },
-        // ],
+        subMenus: goalData.map((goal) => ({
+          name: goal.title ?? '',
+          href: `/goal/${goal.id}`,
+        })),
       },
       {
         icon: <ListCheckIcon />,
@@ -79,7 +74,7 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
       //   href: '/favorite-todo',
       // },
     ];
-  }, []);
+  }, [goalData]);
 
   const sidebar = useMemo<SidebarContextType>(() => {
     const toggle = () => setIsOpen((prev) => !prev);
@@ -89,7 +84,10 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
   }, [allMenus]);
 
   const currentMenu = useMemo(() => {
-    return allMenus.find((menu) => 'href' in menu && menu.href === pathname) || null;
+    return (
+      allMenus.find((menu) => menu.href === pathname || menu.subMenus?.some((subMenu) => subMenu.href === pathname)) ||
+      null
+    );
   }, [allMenus, pathname]);
 
   return (

--- a/src/shared/components/Sidebar/index.tsx
+++ b/src/shared/components/Sidebar/index.tsx
@@ -54,7 +54,6 @@ function SidebarDesktopTablet() {
 
   const menus = getMenus();
   const projectName = 'Bearlog';
-  // console.log('menus: ', menus);
   const { openTodoCreateModal } = useTodoCreateModal();
 
   return (
@@ -147,7 +146,6 @@ function SidebarDesktopTablet() {
               새 목표
             </span>
           </button>
-          {/** TODO:   goalId: undefined as unknown as number 수정 필요 사이드바 전체적으로 연결할 때 해야함 */}
           <button
             onClick={() =>
               openTodoCreateModal({
@@ -229,12 +227,12 @@ function SidebarMenuEntry({ menu, pathname }: { menu: MenuItem; pathname: string
   return (
     <Accordion.Item value={menu.name} className="w-full">
       <AccordionTrigger menu={menu} isActive={isActive} />
-      <AccordionContent>
+      <Accordion.Content className="w-full">
         {menu.subMenus.map((subMenu) => {
           const isSubMenuActive = subMenu.href === pathname;
           return (
             <Link
-              key={subMenu.name}
+              key={subMenu.href}
               href={subMenu.href}
               className={`group flex w-[calc(100%-1rem)] items-center justify-start gap-2 rounded-[20px] px-4 py-1 transition-all duration-200 lg:px-6 lg:py-2`}
             >
@@ -250,7 +248,7 @@ function SidebarMenuEntry({ menu, pathname }: { menu: MenuItem; pathname: string
             </Link>
           );
         })}
-      </AccordionContent>
+      </Accordion.Content>
     </Accordion.Item>
   );
 }
@@ -274,7 +272,7 @@ function AccordionTrigger({ children, menu, isActive, ...props }: AccordionTrigg
         {menu.name}
       </span>
       {children}
-      <span className="ml-auto relative flex h-5 w-5 items-center justify-center text-[#A0A0A0]">
+      <span className="relative ml-auto flex h-5 w-5 items-center justify-center text-[#A0A0A0]">
         <ChevronDownIcon
           className="accordion-chevron-down absolute h-5 w-5 transition-all duration-200 ease-out group-data-[state=open]:-rotate-180 group-data-[state=open]:opacity-0"
           aria-hidden
@@ -285,13 +283,5 @@ function AccordionTrigger({ children, menu, isActive, ...props }: AccordionTrigg
         />
       </span>
     </Accordion.Trigger>
-  );
-}
-
-function AccordionContent({ children, ...props }: React.ComponentPropsWithoutRef<'div'>) {
-  return (
-    <Accordion.Content className="w-full" {...props}>
-      {children}
-    </Accordion.Content>
   );
 }

--- a/src/shared/components/Sidebar/index.tsx
+++ b/src/shared/components/Sidebar/index.tsx
@@ -1,7 +1,18 @@
 'use client';
 import Image from 'next/image';
 import Link from 'next/link';
-import { ChevronsRightIcon, SettingsIcon, LogOutIcon, FlagIcon, CopyCheckIcon, BellIcon, MenuIcon } from 'lucide-react';
+import { usePathname } from 'next/navigation';
+import {
+  ChevronsRightIcon,
+  SettingsIcon,
+  LogOutIcon,
+  FlagIcon,
+  CopyCheckIcon,
+  BellIcon,
+  MenuIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+} from 'lucide-react';
 import { Accordion } from 'radix-ui';
 
 import SidebarMobileCase from './SidebarMobileCase';
@@ -37,6 +48,7 @@ function SidebarDesktopTablet() {
   const { openModal } = useModalStore();
   const { toggle, getMenus } = useSidebarContext();
   const isOpen = useSidebarOpen();
+  const pathname = usePathname();
 
   const { mutate } = usePostGoal();
 
@@ -90,9 +102,13 @@ function SidebarDesktopTablet() {
         </Link>
 
         <div className={`flex w-full flex-col gap-6 transition-all duration-300 ${isOpen ? 'block' : 'hidden'}`}>
-          <Accordion.Root type="multiple" className="flex flex-col gap-3">
+          <Accordion.Root
+            type="multiple"
+            defaultValue={menus.filter((menu) => isMenuActive(menu, pathname)).map((menu) => menu.name)}
+            className="flex flex-col gap-3"
+          >
             {menus.map((menu) => (
-              <LinkPage key={menu.name} menu={menu} />
+              <SidebarMenuEntry key={menu.name} menu={menu} pathname={pathname} />
             ))}
           </Accordion.Root>
 
@@ -185,52 +201,82 @@ function SidebarDesktopTablet() {
   );
 }
 
-interface LinkPageProps {
-  menu: MenuItem;
+function isMenuActive(menu: MenuItem, pathname: string) {
+  return menu.href === pathname || menu.subMenus?.some((subMenu) => subMenu.href === pathname);
 }
-function LinkPage({ menu }: LinkPageProps) {
+
+function getMenuButtonClassName(isActive: boolean | undefined) {
+  return `group flex w-full items-center justify-start gap-[8px] rounded-[20px] px-[12px] py-[10px] transition-all duration-200 lg:px-[16px] lg:py-[14px] ${
+    isActive ? 'bg-[#FEF2E3]' : 'hover:bg-[#FEF2E3]'
+  }`;
+}
+
+function getMenuLabelClassName(isActive: boolean | undefined) {
+  return `text-lg font-semibold transition-all ${isActive ? 'font-bold text-[#DC5203]' : 'text-[#333333] group-hover:font-bold group-hover:text-[#DC5203]'}`;
+}
+
+function getMenuIconClassName(isActive: boolean | undefined) {
+  return isActive ? 'text-[#EF6C00]' : 'text-[#CCCCCC] group-hover:text-[#EF6C00]';
+}
+
+function SidebarMenuEntry({ menu, pathname }: { menu: MenuItem; pathname: string }) {
+  const isActive = isMenuActive(menu, pathname);
+
+  if (!menu.subMenus?.length) {
+    return (
+      <Link href={menu.href} className={getMenuButtonClassName(isActive)}>
+        <span className={getMenuIconClassName(isActive)}>{menu.icon}</span>
+        <span className={getMenuLabelClassName(isActive)}>{menu.name}</span>
+      </Link>
+    );
+  }
+
   return (
-    <Accordion.Item
-      value={menu.name}
-      className="group flex w-full items-center justify-start gap-[8px] rounded-[20px] px-[12px] py-[10px] transition-all duration-200 hover:bg-[#FEF2E3] lg:px-[16px] lg:py-[14px]"
-    >
-      <AccordionTrigger menu={menu}>
-        {menu.subMenus && (
-          <AccordionContent>
-            {menu.subMenus.length > 0 &&
-              menu.subMenus.map((subMenu) => (
-                <Link
-                  key={subMenu.name}
-                  href={subMenu.href}
-                  className="flex w-full items-center justify-start gap-[8px] rounded-[20px] px-[12px] py-[10px] transition-all duration-200 hover:bg-[#FEF2E3] lg:px-[16px] lg:py-[14px]"
-                >
-                  <span className="text-[#CCCCCC] group-hover:text-[#EF6C00]">{subMenu.icon}</span>
-                  <span className="text-lg font-semibold text-[#333333] group-hover:font-bold group-hover:text-[#DC5203]">
-                    {subMenu.name}
-                  </span>
-                </Link>
-              ))}
-          </AccordionContent>
-        )}
-      </AccordionTrigger>
+    <Accordion.Item value={menu.name} className="w-full">
+      <AccordionTrigger menu={menu} isActive={isActive} />
+      <AccordionContent>
+        {menu.subMenus.map((subMenu) => {
+          const isSubMenuActive = subMenu.href === pathname;
+          return (
+            <Link
+              key={subMenu.name}
+              href={subMenu.href}
+              className={`group flex w-[calc(100%-1rem)] items-center justify-start gap-2 rounded-[20px] px-4 py-1 transition-all duration-200 lg:px-6 lg:py-2`}
+            >
+              <span
+                className={`text-base transition-all ${
+                  isSubMenuActive
+                    ? 'font-bold text-[#DC5203]'
+                    : 'font-semibold text-[#666666] group-hover:text-[#DC5203]'
+                }`}
+              >
+                {subMenu.name}
+              </span>
+            </Link>
+          );
+        })}
+      </AccordionContent>
     </Accordion.Item>
   );
 }
 
 interface AccordionTriggerProps extends React.ComponentPropsWithoutRef<'button'> {
   menu: MenuItem;
+  isActive: boolean | undefined;
 }
-function AccordionTrigger({ children, menu, ...props }: AccordionTriggerProps) {
+function AccordionTrigger({ children, menu, isActive, ...props }: AccordionTriggerProps) {
   return (
     <Accordion.Trigger
       {...props}
-      className="flex w-full items-center justify-start gap-[8px] rounded-[20px] px-[12px] py-[10px] transition-all duration-200 hover:bg-[#FEF2E3] lg:px-[16px] lg:py-[14px]"
+      className={`${getMenuButtonClassName(isActive)} [&[data-state=closed]_.accordion-chevron-up]:hidden [&[data-state=open]_.accordion-chevron-down]:hidden`}
     >
-      <span className="text-[#CCCCCC] group-hover:text-[#EF6C00]">{menu.icon}</span>
-      <span className="text-lg font-semibold text-[#333333] group-hover:font-bold group-hover:text-[#DC5203]">
-        {menu.name}
-      </span>
+      <span className={getMenuIconClassName(isActive)}>{menu.icon}</span>
+      <span className={getMenuLabelClassName(isActive)}>{menu.name}</span>
       {children}
+      <span className="ml-auto flex items-center text-[#A0A0A0]">
+        <ChevronDownIcon className="accordion-chevron-down h-5 w-5" aria-hidden />
+        <ChevronUpIcon className="accordion-chevron-up h-5 w-5" aria-hidden />
+      </span>
     </Accordion.Trigger>
   );
 }

--- a/src/shared/components/Sidebar/index.tsx
+++ b/src/shared/components/Sidebar/index.tsx
@@ -2,6 +2,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { ChevronsRightIcon, SettingsIcon, LogOutIcon, FlagIcon, CopyCheckIcon, BellIcon, MenuIcon } from 'lucide-react';
+import { Accordion } from 'radix-ui';
 
 import SidebarMobileCase from './SidebarMobileCase';
 import { SinglePostModal } from '../Modal/SinglePostModal';
@@ -12,6 +13,7 @@ import { useBreakpoint } from '@/shared/hooks/useBreakPoint';
 import { useModalStore } from '@/shared/stores/useModalStore';
 import { usePostGoal } from '@/lib/mutations';
 import { useTodoCreateModal } from '@/features/todo/hooks/useTodoCreateModal';
+import { MenuItem } from '@/contexts/SidebarContext';
 
 export default function Sidebar() {
   const breakpoint = useBreakpoint();
@@ -40,7 +42,7 @@ function SidebarDesktopTablet() {
 
   const menus = getMenus();
   const projectName = 'Bearlog';
-
+  // console.log('menus: ', menus);
   const { openTodoCreateModal } = useTodoCreateModal();
 
   return (
@@ -88,20 +90,11 @@ function SidebarDesktopTablet() {
         </Link>
 
         <div className={`flex w-full flex-col gap-6 transition-all duration-300 ${isOpen ? 'block' : 'hidden'}`}>
-          <div className="flex flex-col gap-3">
+          <Accordion.Root type="multiple" className="flex flex-col gap-3">
             {menus.map((menu) => (
-              <Link
-                key={menu.name}
-                href={menu.href}
-                className="group flex w-full items-center justify-start gap-[8px] rounded-[20px] px-[12px] py-[10px] transition-all duration-200 hover:bg-[#FEF2E3] lg:px-[16px] lg:py-[14px]"
-              >
-                <span className="text-[#CCCCCC] group-hover:text-[#EF6C00]">{menu.icon}</span>
-                <span className="text-lg font-semibold text-[#333333] group-hover:font-bold group-hover:text-[#DC5203]">
-                  {menu.name}
-                </span>
-              </Link>
+              <LinkPage key={menu.name} menu={menu} />
             ))}
-          </div>
+          </Accordion.Root>
 
           <div className="flex w-full flex-col">
             <button className="flex items-center justify-start gap-[10px] rounded-[20px] px-[14px] py-[10px] transition-all duration-100 hover:bg-gray-100">
@@ -189,5 +182,63 @@ function SidebarDesktopTablet() {
         </div>
       </div>
     </div>
+  );
+}
+
+interface LinkPageProps {
+  menu: MenuItem;
+}
+function LinkPage({ menu }: LinkPageProps) {
+  return (
+    <Accordion.Item
+      value={menu.name}
+      className="group flex w-full items-center justify-start gap-[8px] rounded-[20px] px-[12px] py-[10px] transition-all duration-200 hover:bg-[#FEF2E3] lg:px-[16px] lg:py-[14px]"
+    >
+      <AccordionTrigger menu={menu}>
+        {menu.subMenus && (
+          <AccordionContent>
+            {menu.subMenus.length > 0 &&
+              menu.subMenus.map((subMenu) => (
+                <Link
+                  key={subMenu.name}
+                  href={subMenu.href}
+                  className="flex w-full items-center justify-start gap-[8px] rounded-[20px] px-[12px] py-[10px] transition-all duration-200 hover:bg-[#FEF2E3] lg:px-[16px] lg:py-[14px]"
+                >
+                  <span className="text-[#CCCCCC] group-hover:text-[#EF6C00]">{subMenu.icon}</span>
+                  <span className="text-lg font-semibold text-[#333333] group-hover:font-bold group-hover:text-[#DC5203]">
+                    {subMenu.name}
+                  </span>
+                </Link>
+              ))}
+          </AccordionContent>
+        )}
+      </AccordionTrigger>
+    </Accordion.Item>
+  );
+}
+
+interface AccordionTriggerProps extends React.ComponentPropsWithoutRef<'button'> {
+  menu: MenuItem;
+}
+function AccordionTrigger({ children, menu, ...props }: AccordionTriggerProps) {
+  return (
+    <Accordion.Trigger
+      {...props}
+      className="flex w-full items-center justify-start gap-[8px] rounded-[20px] px-[12px] py-[10px] transition-all duration-200 hover:bg-[#FEF2E3] lg:px-[16px] lg:py-[14px]"
+    >
+      <span className="text-[#CCCCCC] group-hover:text-[#EF6C00]">{menu.icon}</span>
+      <span className="text-lg font-semibold text-[#333333] group-hover:font-bold group-hover:text-[#DC5203]">
+        {menu.name}
+      </span>
+      {children}
+    </Accordion.Trigger>
+  );
+}
+
+function AccordionContent({ children, ...props }: React.ComponentPropsWithoutRef<'div'>) {
+  return (
+    <Accordion.Content className="w-full" {...props}>
+      {children}
+    </Accordion.Content>
   );
 }

--- a/src/shared/components/Sidebar/index.tsx
+++ b/src/shared/components/Sidebar/index.tsx
@@ -265,7 +265,7 @@ function AccordionTrigger({ children, menu, isActive, ...props }: AccordionTrigg
       {...props}
       className={`group flex w-full items-center justify-start gap-[8px] rounded-[20px] px-[12px] py-[10px] transition-all duration-200 lg:px-[16px] lg:py-[14px] ${
         isActive ? 'bg-[#FEF2E3]' : 'hover:bg-[#FEF2E3]'
-      } [&[data-state=closed]_.accordion-chevron-up]:hidden [&[data-state=open]_.accordion-chevron-down]:hidden`}
+      }`}
     >
       <span className={isActive ? 'text-[#EF6C00]' : 'text-[#CCCCCC] group-hover:text-[#EF6C00]'}>{menu.icon}</span>
       <span
@@ -274,9 +274,15 @@ function AccordionTrigger({ children, menu, isActive, ...props }: AccordionTrigg
         {menu.name}
       </span>
       {children}
-      <span className="ml-auto flex items-center text-[#A0A0A0]">
-        <ChevronDownIcon className="accordion-chevron-down h-5 w-5" aria-hidden />
-        <ChevronUpIcon className="accordion-chevron-up h-5 w-5" aria-hidden />
+      <span className="ml-auto relative flex h-5 w-5 items-center justify-center text-[#A0A0A0]">
+        <ChevronDownIcon
+          className="accordion-chevron-down absolute h-5 w-5 transition-all duration-200 ease-out group-data-[state=open]:-rotate-180 group-data-[state=open]:opacity-0"
+          aria-hidden
+        />
+        <ChevronUpIcon
+          className="accordion-chevron-up absolute h-5 w-5 rotate-180 opacity-0 transition-all duration-200 ease-out group-data-[state=open]:rotate-0 group-data-[state=open]:opacity-100"
+          aria-hidden
+        />
       </span>
     </Accordion.Trigger>
   );

--- a/src/shared/components/Sidebar/index.tsx
+++ b/src/shared/components/Sidebar/index.tsx
@@ -225,7 +225,7 @@ function SidebarMenuEntry({ menu, pathname }: { menu: MenuItem; pathname: string
   }
 
   return (
-    <Accordion.Item value={menu.name} className="w-full">
+    <Accordion.Item value={menu.name} className="flex w-full flex-col gap-2">
       <AccordionTrigger menu={menu} isActive={isActive} />
       <Accordion.Content className="w-full">
         {menu.subMenus.map((subMenu) => {

--- a/src/shared/components/Sidebar/index.tsx
+++ b/src/shared/components/Sidebar/index.tsx
@@ -205,28 +205,23 @@ function isMenuActive(menu: MenuItem, pathname: string) {
   return menu.href === pathname || menu.subMenus?.some((subMenu) => subMenu.href === pathname);
 }
 
-function getMenuButtonClassName(isActive: boolean | undefined) {
-  return `group flex w-full items-center justify-start gap-[8px] rounded-[20px] px-[12px] py-[10px] transition-all duration-200 lg:px-[16px] lg:py-[14px] ${
-    isActive ? 'bg-[#FEF2E3]' : 'hover:bg-[#FEF2E3]'
-  }`;
-}
-
-function getMenuLabelClassName(isActive: boolean | undefined) {
-  return `text-lg font-semibold transition-all ${isActive ? 'font-bold text-[#DC5203]' : 'text-[#333333] group-hover:font-bold group-hover:text-[#DC5203]'}`;
-}
-
-function getMenuIconClassName(isActive: boolean | undefined) {
-  return isActive ? 'text-[#EF6C00]' : 'text-[#CCCCCC] group-hover:text-[#EF6C00]';
-}
-
 function SidebarMenuEntry({ menu, pathname }: { menu: MenuItem; pathname: string }) {
   const isActive = isMenuActive(menu, pathname);
 
   if (!menu.subMenus?.length) {
     return (
-      <Link href={menu.href} className={getMenuButtonClassName(isActive)}>
-        <span className={getMenuIconClassName(isActive)}>{menu.icon}</span>
-        <span className={getMenuLabelClassName(isActive)}>{menu.name}</span>
+      <Link
+        href={menu.href}
+        className={`group flex w-full items-center justify-start gap-[8px] rounded-[20px] px-[12px] py-[10px] transition-all duration-200 lg:px-[16px] lg:py-[14px] ${
+          isActive ? 'bg-[#FEF2E3]' : 'hover:bg-[#FEF2E3]'
+        }`}
+      >
+        <span className={isActive ? 'text-[#EF6C00]' : 'text-[#CCCCCC] group-hover:text-[#EF6C00]'}>{menu.icon}</span>
+        <span
+          className={`text-lg font-semibold transition-all ${isActive ? 'font-bold text-[#DC5203]' : 'text-[#333333] group-hover:font-bold group-hover:text-[#DC5203]'}`}
+        >
+          {menu.name}
+        </span>
       </Link>
     );
   }
@@ -268,10 +263,16 @@ function AccordionTrigger({ children, menu, isActive, ...props }: AccordionTrigg
   return (
     <Accordion.Trigger
       {...props}
-      className={`${getMenuButtonClassName(isActive)} [&[data-state=closed]_.accordion-chevron-up]:hidden [&[data-state=open]_.accordion-chevron-down]:hidden`}
+      className={`group flex w-full items-center justify-start gap-[8px] rounded-[20px] px-[12px] py-[10px] transition-all duration-200 lg:px-[16px] lg:py-[14px] ${
+        isActive ? 'bg-[#FEF2E3]' : 'hover:bg-[#FEF2E3]'
+      } [&[data-state=closed]_.accordion-chevron-up]:hidden [&[data-state=open]_.accordion-chevron-down]:hidden`}
     >
-      <span className={getMenuIconClassName(isActive)}>{menu.icon}</span>
-      <span className={getMenuLabelClassName(isActive)}>{menu.name}</span>
+      <span className={isActive ? 'text-[#EF6C00]' : 'text-[#CCCCCC] group-hover:text-[#EF6C00]'}>{menu.icon}</span>
+      <span
+        className={`text-lg font-semibold transition-all ${isActive ? 'font-bold text-[#DC5203]' : 'text-[#333333] group-hover:font-bold group-hover:text-[#DC5203]'}`}
+      >
+        {menu.name}
+      </span>
       {children}
       <span className="ml-auto flex items-center text-[#A0A0A0]">
         <ChevronDownIcon className="accordion-chevron-down h-5 w-5" aria-hidden />

--- a/src/shared/components/TaskCard/index.tsx
+++ b/src/shared/components/TaskCard/index.tsx
@@ -64,7 +64,7 @@ interface TaskCheckboxProps {
 }
 
 function TaskCheckbox({ todo, isOrange, onToggle, onTitleClick }: TaskCheckboxProps) {
-  const [checked, setChecked] = useState(todo.done);
+  const [checked, setChecked] = useState(todo.done ?? false);
 
   function handleToggle() {
     setChecked((prev) => !prev);
@@ -191,7 +191,7 @@ function TaskEditTodo({ isOrange, todo }: TaskLinkDetailProps) {
 
             openTodoEditModal({
               goalDetailId: todo.goal?.id,
-              todo: { id: todo.id, title: todo.title, done: todo.done },
+              todo: { id: todo.id, title: todo.title, done: todo.done ?? false },
             });
             setOpen(false);
           }}

--- a/src/shared/components/TaskCard/index.tsx
+++ b/src/shared/components/TaskCard/index.tsx
@@ -2,6 +2,7 @@
 
 import clsx from 'clsx';
 import Image from 'next/image';
+import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
 import { useRef, useState } from 'react';
 import { CheckIcon, EllipsisVertical, GithubIcon, Star } from 'lucide-react';
@@ -11,6 +12,7 @@ import EditDeleteDropdown from '@/features/dashboard/components/EditDeleteDropdo
 import { useTodoEditModal } from '@/features/todo/hooks/useTodoEditModal';
 import type { TodoResponse } from '@/lib/api';
 import { useDeleteTodo, usePatchTodoFavorite } from '@/lib/mutations';
+import { todoQueries } from '@/lib/queryKeys';
 
 interface TaskCardProps {
   todo: NonNullable<TodoResponse>;
@@ -113,9 +115,15 @@ interface TaskLinkNoteCreateProps {
 }
 
 function TaskLinkNoteCreate({ isOrange, todo }: TaskLinkNoteCreateProps) {
+  const { data: goal } = useQuery({
+    ...todoQueries.detail(todo.id as number),
+    enabled: !!todo.id,
+  });
+
+  if (!goal?.goal?.id || !todo.id) return null;
   return (
     <Link
-      href={`/goal/${todo.goal?.id}/note/create`}
+      href={`/goal/${goal.goal.id}/note/create?todoId=${todo.id}`}
       className={clsx(
         'relative flex h-6 w-6 cursor-pointer items-center justify-center rounded-full p-1 group-hover:bg-white',
         isOrange ? 'bg-[#FFFFFF]/40' : 'bg-[#FF9E59]/20',


### PR DESCRIPTION
## 무엇을 변경했나요?

1. 사이드바 목표 서브 메뉴들 연결 
2. 기본 `TaskCard` 노트생성 이동 버튼을 연결수정

## 왜 이렇게 했나요?
1. 사이드바 목표 서브 메뉴들 `src/contexts/SidebarContext.tsx` 에서 리액트 쿼리로 해당 목표들을 불러오고 해당 목표들을 렌더링합니다.
2. Accordion으로 사이드바를 재구성했습니다 [해당 공식문서](https://www.radix-ui.com/primitives/docs/components/accordion)
3. 기본 `TaskCard` 노트생성 이동 버튼을 연결수정했고 `src/app/(main)/goal/[goalId]/note/create/page.tsx` 도 todoId searchParams 활성화 했습니다 
4. `src/shared/components/TaskCard/index.tsx` 에서 해당 todo들에서 goal을 받아오지 못해 리액트 쿼리로 todo detail로 받아와 goal id를 받아오도록 했습니다

## 리뷰어가 특히 봐줬으면 하는 부분

- 사이드바 목표 렌더링
- 노트 생성페이지 이동

## 스크린샷 (UI 변경 시)
<img width="392" height="690" alt="image" src="https://github.com/user-attachments/assets/a74d3958-c97e-47ab-bdaa-3bfb95f12aaf" />
