### PR TITLE
[refactor/dashboard-mutation] - 대시보드 낙관적 업데이트 처리

### DIFF
--- a/src/app/api/proxy/[...endpoint]/route.ts
+++ b/src/app/api/proxy/[...endpoint]/route.ts
@@ -10,21 +10,75 @@ const AUTH_COOKIE_OPTIONS = {
   path: '/',
 };
 
+const ACCESS_TOKEN_COOKIE = 'accessToken';
+const REFRESH_TOKEN_COOKIE = 'refreshToken';
+const REFRESH_ENDPOINT = 'auth/refresh';
+
 const FORWARDED_REQUEST_HEADERS = ['accept', 'content-type'] as const;
 const FORWARDED_RESPONSE_HEADERS = ['content-type', 'location'] as const;
+
+const ALLOWED_PATH_PREFIXES = ['auth/', 'todos', 'goals', 'notes', 'notifications', 'tags', 'users/me'] as const;
 
 type ProxyRouteContext = {
   params: Promise<{ endpoint: string[] }>;
 };
 
+const isAllowedPath = (pathname: string) => {
+  return ALLOWED_PATH_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}`));
+};
+
+const shouldSyncAuthCookies = (pathname: string) => {
+  return pathname.startsWith('auth/');
+};
+
+const buildUpstreamHeaders = (request: NextRequest, accessToken?: string) => {
+  const headers = new Headers();
+
+  for (const headerName of FORWARDED_REQUEST_HEADERS) {
+    const headerValue = request.headers.get(headerName);
+    if (headerValue) {
+      headers.set(headerName, headerValue);
+    }
+  }
+
+  if (accessToken) {
+    headers.set('Authorization', `Bearer ${accessToken}`);
+  }
+
+  return headers;
+};
+
+const buildResponseHeaders = (response: Response) => {
+  const headers = new Headers();
+
+  for (const headerName of FORWARDED_RESPONSE_HEADERS) {
+    const headerValue = response.headers.get(headerName);
+    if (headerValue) {
+      headers.set(headerName, headerValue);
+    }
+  }
+
+  return headers;
+};
+
+const copyResponse = async (response: Response) => {
+  const headers = buildResponseHeaders(response);
+  const body = response.status === 204 ? null : await response.arrayBuffer();
+
+  return new NextResponse(body, {
+    status: response.status,
+    headers,
+  });
+};
+
 const syncAuthCookies = async (pathname: string, response: Response, nextResponse: NextResponse) => {
-  if (!response.ok) {
+  if (!shouldSyncAuthCookies(pathname) || !response.ok) {
     return;
   }
 
   if (pathname === 'auth/logout') {
-    nextResponse.cookies.delete('accessToken');
-    nextResponse.cookies.delete('refreshToken');
+    nextResponse.cookies.delete(ACCESS_TOKEN_COOKIE);
+    nextResponse.cookies.delete(REFRESH_TOKEN_COOKIE);
     return;
   }
 
@@ -40,20 +94,85 @@ const syncAuthCookies = async (pathname: string, response: Response, nextRespons
     };
 
     if (data.accessToken) {
-      nextResponse.cookies.set('accessToken', data.accessToken, {
+      nextResponse.cookies.set(ACCESS_TOKEN_COOKIE, data.accessToken, {
         ...AUTH_COOKIE_OPTIONS,
         maxAge: 60 * 30,
       });
     }
 
     if (data.refreshToken) {
-      nextResponse.cookies.set('refreshToken', data.refreshToken, {
+      nextResponse.cookies.set(REFRESH_TOKEN_COOKIE, data.refreshToken, {
         ...AUTH_COOKIE_OPTIONS,
         maxAge: 60 * 60 * 24 * 7,
       });
     }
   } catch {
-    // Ignore unexpected non-JSON auth responses.
+    // auth 응답이 예상한 JSON 형식이 아니면 무시
+  }
+};
+
+const requestUpstream = async ({
+  request,
+  pathname,
+  search,
+  accessToken,
+  body,
+}: {
+  request: NextRequest;
+  pathname: string;
+  search: string;
+  accessToken?: string;
+  body?: string;
+}) => {
+  const targetUrl = `${apiBaseUrl}/api/v1/${pathname}${search}`;
+  const headers = buildUpstreamHeaders(request, accessToken);
+
+  return fetch(targetUrl, {
+    method: request.method,
+    headers,
+    body: ['GET', 'HEAD'].includes(request.method) ? undefined : body,
+    cache: 'no-store',
+  });
+};
+
+const refreshAccessToken = async (refreshToken?: string) => {
+  if (!refreshToken) return null;
+
+  const refreshUrl = `${apiBaseUrl}/api/v1/${REFRESH_ENDPOINT}`;
+
+  const response = await fetch(refreshUrl, {
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      Authorization: `Bearer ${refreshToken}`,
+    },
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const cloned = response.clone();
+
+  try {
+    const data = (await response.json()) as {
+      accessToken?: string;
+      refreshToken?: string;
+    };
+
+    if (!data.accessToken) {
+      return null;
+    }
+
+    return {
+      accessToken: data.accessToken,
+      refreshToken: data.refreshToken,
+      response: cloned,
+    };
+  } catch {
+    return null;
   }
 };
 
@@ -64,47 +183,74 @@ const handler = async (request: NextRequest, context: ProxyRouteContext) => {
 
   const { endpoint } = await context.params;
   const pathname = endpoint.join('/');
-  const targetUrl = `${apiBaseUrl}/api/v1/${pathname}${request.nextUrl.search}`;
+
+  if (!pathname || !isAllowedPath(pathname)) {
+    return NextResponse.json({ message: 'Not allowed path' }, { status: 404 });
+  }
 
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get('accessToken')?.value;
+  const accessToken = cookieStore.get(ACCESS_TOKEN_COOKIE)?.value;
+  const refreshToken = cookieStore.get(REFRESH_TOKEN_COOKIE)?.value;
 
-  const upstreamHeaders = new Headers();
-  for (const headerName of FORWARDED_REQUEST_HEADERS) {
-    const headerValue = request.headers.get(headerName);
-    if (headerValue) {
-      upstreamHeaders.set(headerName, headerValue);
+  const requestBody = ['GET', 'HEAD'].includes(request.method) ? undefined : await request.text();
+
+  try {
+    let upstreamResponse = await requestUpstream({
+      request,
+      pathname,
+      search: request.nextUrl.search,
+      accessToken,
+      body: requestBody,
+    });
+
+    // auth 관련 요청은 그대로 응답 + 쿠키 동기화
+    if (shouldSyncAuthCookies(pathname)) {
+      const authResponse = upstreamResponse.clone();
+      const nextResponse = await copyResponse(upstreamResponse);
+      await syncAuthCookies(pathname, authResponse, nextResponse);
+      return nextResponse;
     }
-  }
 
-  if (accessToken) {
-    upstreamHeaders.set('Authorization', `Bearer ${accessToken}`);
-  }
+    // 일반 API 요청에서 accessToken 만료 시 refresh 후 1회 재시도
+    if (upstreamResponse.status === 401 && refreshToken) {
+      const refreshed = await refreshAccessToken(refreshToken);
 
-  const response = await fetch(targetUrl, {
-    method: request.method,
-    headers: upstreamHeaders,
-    body: ['GET', 'HEAD'].includes(request.method) ? undefined : await request.text(),
-    cache: 'no-store',
-  });
-  const authResponse = response.clone();
+      if (refreshed?.accessToken) {
+        upstreamResponse = await requestUpstream({
+          request,
+          pathname,
+          search: request.nextUrl.search,
+          accessToken: refreshed.accessToken,
+          body: requestBody,
+        });
 
-  const responseHeaders = new Headers();
-  for (const headerName of FORWARDED_RESPONSE_HEADERS) {
-    const headerValue = response.headers.get(headerName);
-    if (headerValue) {
-      responseHeaders.set(headerName, headerValue);
+        const nextResponse = await copyResponse(upstreamResponse);
+
+        nextResponse.cookies.set(ACCESS_TOKEN_COOKIE, refreshed.accessToken, {
+          ...AUTH_COOKIE_OPTIONS,
+          maxAge: 60 * 30,
+        });
+
+        if (refreshed.refreshToken) {
+          nextResponse.cookies.set(REFRESH_TOKEN_COOKIE, refreshed.refreshToken, {
+            ...AUTH_COOKIE_OPTIONS,
+            maxAge: 60 * 60 * 24 * 7,
+          });
+        }
+
+        return nextResponse;
+      }
+
+      const unauthorizedResponse = await copyResponse(upstreamResponse);
+      unauthorizedResponse.cookies.delete(ACCESS_TOKEN_COOKIE);
+      unauthorizedResponse.cookies.delete(REFRESH_TOKEN_COOKIE);
+      return unauthorizedResponse;
     }
+
+    return copyResponse(upstreamResponse);
+  } catch {
+    return NextResponse.json({ message: 'Upstream request failed' }, { status: 502 });
   }
-
-  const nextResponse = new NextResponse(response.status === 204 ? null : await response.arrayBuffer(), {
-    status: response.status,
-    headers: responseHeaders,
-  });
-
-  await syncAuthCookies(pathname, authResponse, nextResponse);
-
-  return nextResponse;
 };
 
 export const GET = handler;

--- a/src/features/dashboard/allTodo/components/AllTodoContent/index.tsx
+++ b/src/features/dashboard/allTodo/components/AllTodoContent/index.tsx
@@ -19,11 +19,12 @@ export default function AllTodoContent() {
   const breakpoint = useBreakpoint();
 
   const [selectedFilter, setSelectedFilter] = useState<TodoOptions>('ALL');
-  const { data: todoList } = useQuery(
-    todoQueries.list({
-      done: selectedFilter === 'ALL' ? undefined : selectedFilter === 'DONE' ? true : false,
-    }),
-  );
+  const done = selectedFilter === 'ALL' ? undefined : selectedFilter === 'DONE';
+
+  const { data: todoList } = useQuery({
+    ...todoQueries.list({ done }),
+    placeholderData: (prev) => prev,
+  });
 
   if (!todoList) return null;
   return (

--- a/src/features/dashboard/components/GoalBox/index.tsx
+++ b/src/features/dashboard/components/GoalBox/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useState } from 'react';
+import { AnimatePresence } from 'framer-motion';
 import { PlusIcon } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
@@ -111,9 +112,11 @@ function ListBox({ title, mode, items }: ListBoxProps) {
     <div className={`flex max-h-[324px] flex-1 flex-col gap-4 rounded-[16px] ${bgColor} p-4 lg:rounded-[24px] lg:p-6`}>
       <span className={`text-sm font-bold ${textColor} lg:text-base`}>{title}</span>
       <div className="flex max-h-[236px] flex-col gap-1 overflow-y-auto">
-        {items.map((item) => (
-          <TaskCardWrapper key={item.id} item={item} mode={mode} />
-        ))}
+        <AnimatePresence initial={false} mode="popLayout">
+          {items.map((item) => (
+            <TaskCardWrapper key={item.id} item={item} mode={mode} />
+          ))}
+        </AnimatePresence>
       </div>
     </div>
   );

--- a/src/features/dashboard/components/TaskCardWrapper/index.tsx
+++ b/src/features/dashboard/components/TaskCardWrapper/index.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { motion } from 'framer-motion';
 import { useState } from 'react';
 
 import TaskCard from '@/shared/components/TaskCard';
@@ -60,11 +61,23 @@ export default function TaskCardWrapper({
 
   if (!todoDetail) return null;
   return (
-    <TaskCard
-      variant={mode === 'todo' ? 'green' : 'default'}
-      todo={todoDetail}
-      onCheckboxClick={handleCheckboxClick}
-      onStareClick={handleStarToggle}
-    />
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: 10, scale: 0.98 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{ opacity: 0, y: -10, scale: 0.98 }}
+      transition={{
+        duration: 0.24,
+        ease: [0.22, 1, 0.36, 1],
+        layout: { duration: 0.28, ease: [0.22, 1, 0.36, 1] },
+      }}
+    >
+      <TaskCard
+        variant={mode === 'todo' ? 'green' : 'default'}
+        todo={todoDetail}
+        onCheckboxClick={handleCheckboxClick}
+        onStareClick={handleStarToggle}
+      />
+    </motion.div>
   );
 }

--- a/src/features/todo/components/manual/TodoFormModal/index.tsx
+++ b/src/features/todo/components/manual/TodoFormModal/index.tsx
@@ -2,7 +2,7 @@
 
 import clsx from 'clsx';
 import { XIcon } from 'lucide-react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { useQuery } from '@tanstack/react-query';
 
@@ -16,7 +16,7 @@ import LinkInput from '../shared/LinkInput';
 import StatusField from '../shared/StatusField';
 import TagInput from '../shared/TagInput';
 
-import { PatchTodoRequest, PostTodoRequest } from '@/shared/lib/api';
+import { ApiError, PatchTodoRequest, PostTodoRequest } from '@/shared/lib/api';
 import { usePatchTodo, usePostTodo } from '@/shared/lib/mutations';
 import { goalQueries, todoQueries } from '@/shared/lib/queryKeys';
 import { useModalStore } from '@/shared/stores/useModalStore';
@@ -41,6 +41,7 @@ type TodoFormValues = PostTodoRequest & PatchTodoRequest;
 export default function TodoFormModal({ mode, todo, goalDetailId }: TodoFormModalProps) {
   const { closeModal } = useModalStore();
   const isEditMode = mode === 'edit';
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const {
     register,
@@ -92,6 +93,7 @@ export default function TodoFormModal({ mode, todo, goalDetailId }: TodoFormModa
 
   const postTodoMutation = usePostTodo();
   const patchTodoMutation = usePatchTodo(todoId);
+  const isSubmitting = postTodoMutation.isPending || patchTodoMutation.isPending;
 
   useEffect(() => {
     if (!isEditMode || !todoDetail) return;
@@ -132,6 +134,8 @@ export default function TodoFormModal({ mode, todo, goalDetailId }: TodoFormModa
       : goalOptions[0]?.value;
 
   const onSubmit = async (data: TodoFormValues) => {
+    setSubmitError(null);
+
     try {
       if (isEditMode && 'id' in todo) {
         await patchTodoMutation.mutateAsync({
@@ -156,7 +160,7 @@ export default function TodoFormModal({ mode, todo, goalDetailId }: TodoFormModa
 
       closeModal();
     } catch (error) {
-      console.error(error);
+      setSubmitError(error instanceof ApiError ? error.message : '요청 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
     }
   };
 
@@ -172,10 +176,17 @@ export default function TodoFormModal({ mode, todo, goalDetailId }: TodoFormModa
     >
       <div className="mb-1 flex items-center justify-between md:mb-4">
         <h1 className="text-xl font-semibold text-gray-800">{isEditMode ? '할 일 수정' : '할 일 생성'}</h1>
-        <button type="button" className="cursor-pointer" onClick={closeModal}>
+        <button
+          type="button"
+          className="cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+          onClick={closeModal}
+          disabled={isSubmitting}
+        >
           <XIcon size={24} className="stroke-gray-400" />
         </button>
       </div>
+
+      {submitError && <p className="rounded-2xl bg-red-50 px-4 py-3 text-sm text-red-500">{submitError}</p>}
 
       {isEditMode && (
         <StatusField
@@ -258,10 +269,11 @@ export default function TodoFormModal({ mode, todo, goalDetailId }: TodoFormModa
           variant="tertiary"
           className="h-12 w-full border border-gray-300 text-gray-500 md:h-14"
           onClick={closeModal}
+          disabled={isSubmitting}
         >
           취소
         </Button>
-        <Button type="submit" variant="primary" className="h-12 w-full md:h-14">
+        <Button type="submit" variant="primary" className="h-12 w-full md:h-14" disabled={isSubmitting}>
           확인
         </Button>
       </div>

--- a/src/features/todo/components/manual/TodoFormModal/index.tsx
+++ b/src/features/todo/components/manual/TodoFormModal/index.tsx
@@ -132,28 +132,32 @@ export default function TodoFormModal({ mode, todo, goalDetailId }: TodoFormModa
       : goalOptions[0]?.value;
 
   const onSubmit = async (data: TodoFormValues) => {
-    if (isEditMode && 'id' in todo) {
-      await patchTodoMutation.mutateAsync({
-        title: data.title,
-        dueDate: data.dueDate,
-        linkUrl: data.linkUrl ?? null,
-        imageUrl: data.imageUrl ?? null,
-        tags: data.tags,
-        done: data.done,
-      });
-    } else {
-      await postTodoMutation.mutateAsync({
-        source: 'MANUAL',
-        title: data.title,
-        goalId: data.goalId,
-        dueDate: data.dueDate,
-        linkUrl: data.linkUrl ?? undefined,
-        imageUrl: data.imageUrl ?? undefined,
-        tags: data.tags,
-      });
-    }
+    try {
+      if (isEditMode && 'id' in todo) {
+        await patchTodoMutation.mutateAsync({
+          title: data.title,
+          dueDate: data.dueDate,
+          linkUrl: data.linkUrl ?? null,
+          imageUrl: data.imageUrl ?? null,
+          tags: data.tags,
+          done: data.done,
+        });
+      } else {
+        await postTodoMutation.mutateAsync({
+          source: 'MANUAL',
+          title: data.title,
+          goalId: data.goalId,
+          dueDate: data.dueDate,
+          linkUrl: data.linkUrl ?? undefined,
+          imageUrl: data.imageUrl ?? undefined,
+          tags: data.tags,
+        });
+      }
 
-    closeModal();
+      closeModal();
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (

--- a/src/features/todo/components/manual/TodoFormModal/index.tsx
+++ b/src/features/todo/components/manual/TodoFormModal/index.tsx
@@ -16,7 +16,7 @@ import LinkInput from '../shared/LinkInput';
 import StatusField from '../shared/StatusField';
 import TagInput from '../shared/TagInput';
 
-import { PatchTodoRequest, PatchTodoRequestWithNull, PostTodoRequest } from '@/shared/lib/api';
+import { PatchTodoRequest, PostTodoRequest } from '@/shared/lib/api';
 import { usePatchTodo, usePostTodo } from '@/shared/lib/mutations';
 import { goalQueries, todoQueries } from '@/shared/lib/queryKeys';
 import { useModalStore } from '@/shared/stores/useModalStore';
@@ -32,11 +32,11 @@ interface CreateMode extends BaseProps {
 
 interface EditMode extends BaseProps {
   mode: 'edit';
-  todo: PatchTodoRequestWithNull & { id: number };
+  todo: PatchTodoRequest & { id: number };
 }
 
 type TodoFormModalProps = CreateMode | EditMode;
-type TodoFormValues = PostTodoRequest & PatchTodoRequestWithNull;
+type TodoFormValues = PostTodoRequest & PatchTodoRequest;
 
 export default function TodoFormModal({ mode, todo, goalDetailId }: TodoFormModalProps) {
   const { closeModal } = useModalStore();
@@ -73,7 +73,7 @@ export default function TodoFormModal({ mode, todo, goalDetailId }: TodoFormModa
 
   register('dueDate', { required: '마감기한은 필수입니다.' });
 
-  const tags = useWatch({ control, name: 'tags' }) ?? [];
+  const tags = (useWatch({ control, name: 'tags' }) ?? []).filter((tag): tag is string => tag !== null);
   const goalId = useWatch({ control, name: 'goalId' });
   const linkUrl = useWatch({ control, name: 'linkUrl' });
   const imageUrl = useWatch({ control, name: 'imageUrl' }) ?? null;
@@ -102,7 +102,7 @@ export default function TodoFormModal({ mode, todo, goalDetailId }: TodoFormModa
       dueDate: todoDetail.dueDate ?? undefined,
       linkUrl: todoDetail.linkUrl ?? undefined,
       imageUrl: todoDetail.imageUrl ?? undefined,
-      tags: todoDetail.tags ? todoDetail.tags.map((tag) => tag.name) : [],
+      tags: todoDetail.tags ? todoDetail.tags.map((tag) => tag.name).filter((tag): tag is string => tag !== null) : [],
       done: todoDetail.done ?? false,
     });
   }, [isEditMode, reset, todoDetail]);

--- a/src/shared/components/ProgressCircle/index.tsx
+++ b/src/shared/components/ProgressCircle/index.tsx
@@ -50,6 +50,7 @@ export default function ProgressCircle({ className, color = '#008354', percent }
           transform: 'rotate(90deg) scaleX(-1)',
           transformOrigin: '50% 50%',
         }}
+        className="duration-300 ease-in-out"
       />
     </svg>
   );

--- a/src/shared/components/Progressbar/index.tsx
+++ b/src/shared/components/Progressbar/index.tsx
@@ -1,3 +1,6 @@
+import { useEffect } from 'react';
+import { motion, useSpring, useTransform } from 'framer-motion';
+
 interface ProgressbarProps {
   /**
    * @description
@@ -11,15 +14,31 @@ interface ProgressbarProps {
   number?: boolean;
 }
 export default function Progressbar({ progress, number = true }: ProgressbarProps) {
+  const safeProgress = Math.min(100, Math.max(0, progress));
+  const springProgress = useSpring(0, {
+    stiffness: 120,
+    damping: 20,
+    mass: 0.8,
+  });
+  const animatedLabel = useTransform(() => `${Math.round(springProgress.get())}%`);
+
+  useEffect(() => {
+    springProgress.set(safeProgress);
+  }, [safeProgress, springProgress]);
+
   return (
-    <div className="flex w-full items-center gap-[8px] transition-all duration-300 md:gap-[10px]">
-      <div className="h-2 w-full rounded bg-[#E9E9E9]">
-        <div className="bg-bearlog-500 h-full rounded" style={{ width: `${progress}%` }}></div>
+    <div className="flex w-full items-center gap-[8px] transition-all duration-300 ease-in-out md:gap-[10px]">
+      <div className="h-2 w-full overflow-hidden rounded bg-[#E9E9E9]">
+        <motion.div
+          className="bg-bearlog-500 h-full rounded"
+          animate={{ width: `${safeProgress}%` }}
+          transition={{ type: 'spring', stiffness: 120, damping: 20, mass: 0.8 }}
+        />
       </div>
       {number && (
-        <span className="text-bearlog-500 text-sm transition-all duration-300 md:text-base md:font-bold">
-          {progress}%
-        </span>
+        <motion.span className="text-bearlog-500 text-sm transition-all duration-300 ease-in-out md:text-base md:font-bold">
+          {animatedLabel}
+        </motion.span>
       )}
     </div>
   );

--- a/src/shared/components/TaskCard/index.tsx
+++ b/src/shared/components/TaskCard/index.tsx
@@ -31,7 +31,7 @@ export default function TaskCard({ todo, onCheckboxClick, onStareClick, variant 
         'cursor-pointer',
         'relative flex items-center gap-2',
         'rounded-2xl px-2 py-2.5',
-        'transition-all duration-150',
+        'transition-all duration-150 ease-in-out',
         'hover:bg-[rgba(0,200,127,0.1)]',
       )}
     >
@@ -67,9 +67,9 @@ function TaskCheckbox({ todo, isGreen, onCheckboxClick }: TaskCheckboxProps) {
           clsx(
             'relative flex cursor-pointer items-center justify-center',
             'size-4.5 shrink-0 rounded-md',
-            'transition-all duration-150',
-            todo.done ? 'bg-bearlog-500 border-transparent' : 'border border-gray-300 bg-white',
-            isGreen && 'border-none',
+            'transition-all duration-150 ease-in-out',
+            todo.done ? 'bg-bearlog-500 border-none' : 'border border-gray-300 bg-white',
+            isGreen ? '' : 'border-none',
           ),
         )}
       >
@@ -83,7 +83,7 @@ function TaskCheckbox({ todo, isGreen, onCheckboxClick }: TaskCheckboxProps) {
         className={clsx(
           'group min-w-0 flex-1 cursor-pointer truncate text-left',
           'text-base leading-6 tracking-[-0.03em]',
-          'transition-all duration-150',
+          'transition-all duration-150 ease-in-out',
           todo.done ? 'group-hover:text-bearlog-600 font-medium group-hover:font-semibold' : '',
           isGreen ? 'text-gray-800' : 'group-hover:text-bearlog-600 text-gray-500 group-hover:font-semibold',
         )}

--- a/src/shared/lib/api/fetchTodos.ts
+++ b/src/shared/lib/api/fetchTodos.ts
@@ -12,11 +12,6 @@ export type PatchTodoRequest = operations['update']['requestBody']['content']['a
 export type PatchTodoResponse = operations['update']['responses'][200]['content']['application/json'];
 export type PatchTodoFavoriteResponse = operations['toggleFavorite']['responses'][200]['content']['application/json'];
 
-export type PatchTodoRequestWithNull = Omit<PatchTodoRequest, 'imageUrl' | 'linkUrl'> & {
-  imageUrl?: string | null;
-  linkUrl?: string | null;
-};
-
 class FetchTodos {
   getTodos = (params?: GetTodosParams) => apiRequest<TodoListResponse>('/api/v1/todos', { params });
 
@@ -31,8 +26,8 @@ class FetchTodos {
       body,
     });
 
-  patchTodo = (todoId: number, body: PatchTodoRequestWithNull) =>
-    apiRequest<PatchTodoResponse, PatchTodoRequestWithNull>(`/api/v1/todos/${todoId}`, {
+  patchTodo = (todoId: number, body: PatchTodoRequest) =>
+    apiRequest<PatchTodoResponse, PatchTodoRequest>(`/api/v1/todos/${todoId}`, {
       method: 'PATCH',
       body,
     });

--- a/src/shared/lib/api/utils.ts
+++ b/src/shared/lib/api/utils.ts
@@ -1,4 +1,10 @@
-type QueryValue = string | number | boolean | null | undefined | Array<string | number | boolean>;
+type QueryValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | Array<string | number | boolean | null | undefined>;
 
 export class ApiError extends Error {
   constructor(
@@ -21,6 +27,7 @@ export const toQueryString = (params?: Record<string, QueryValue>): string => {
 
     if (Array.isArray(value)) {
       for (const item of value) {
+        if (item === undefined || item === null) continue;
         searchParams.append(key, String(item));
       }
       continue;

--- a/src/shared/lib/mutations.ts
+++ b/src/shared/lib/mutations.ts
@@ -1,9 +1,16 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
-import { fetchGoals, PostGoalRequest } from './api/fetchGoals';
+import { fetchGoals, GoalListResponse, PatchGoalResponse, PostGoalRequest } from './api/fetchGoals';
 import { fetchAuth } from './api';
-import { fetchTodos, PatchTodoRequest, PostTodoRequest } from './api/fetchTodos';
+import {
+  fetchTodos,
+  PatchTodoFavoriteResponse,
+  PatchTodoRequest,
+  PatchTodoResponse,
+  PostTodoRequest,
+  TodoListResponse,
+} from './api/fetchTodos';
 import { fetchUsers, PatchCurrentUserRequest, PatchCurrentUserPasswordRequest } from './api/fetchUsers';
 import { useToastStore } from '@/shared/stores/useToastStore';
 
@@ -19,6 +26,22 @@ export const usePostGoal = () => {
       }
 
       return fetchGoals.postGoal(data);
+    },
+    onMutate: async (data: PostGoalRequest) => {
+      await queryClient.cancelQueries({ queryKey: ['goals', 'list'] });
+      const previousGoals = queryClient.getQueryData(['goals', 'list']);
+      queryClient.setQueryData(['goals', 'list'], (old: GoalListResponse) => ({
+        ...old,
+        items: [
+          {
+            id: Math.random(),
+            title: data.title,
+            todos: [],
+          },
+          ...(old?.goals ?? []),
+        ],
+      }));
+      return { previousGoals };
     },
     onSuccess: () => {
       showToast('목표가 생성되었습니다.');
@@ -38,6 +61,12 @@ export const useDeleteGoal = (goalId?: number) => {
         throw new Error('Goal id is required');
       }
       return fetchGoals.deleteGoal(goalId);
+    },
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: ['goals', 'detail', goalId] });
+      const previousGoal = queryClient.getQueryData(['goals', 'detail', goalId]);
+      queryClient.setQueryData(['goals', 'detail', goalId], undefined);
+      return { previousGoal };
     },
     onSuccess: () => {
       showToast('목표가 삭제되었습니다.');
@@ -60,6 +89,15 @@ export const usePatchGoal = (goalId?: number) => {
         throw new Error('Goal id is required');
       }
       return fetchGoals.patchGoal(goalId, data);
+    },
+    onMutate: async (data: { title: string }) => {
+      await queryClient.cancelQueries({ queryKey: ['goals', 'detail', goalId] });
+      const previousGoal = queryClient.getQueryData(['goals', 'detail', goalId]);
+      queryClient.setQueryData(['goals', 'detail', goalId], (old: PatchGoalResponse) => ({
+        ...old,
+        title: data.title,
+      }));
+      return { previousGoal };
     },
     onSuccess: () => {
       showToast('목표가 수정되었습니다.');
@@ -84,6 +122,26 @@ export const usePostTodo = () => {
       }
       return fetchTodos.postTodo(data);
     },
+    onMutate: async (data: PostTodoRequest) => {
+      await queryClient.cancelQueries({ queryKey: ['todos', 'list'] });
+      const previousTodos = queryClient.getQueryData(['todos', 'list']);
+      queryClient.setQueryData(['todos', 'list'], (old: TodoListResponse) => ({
+        ...old,
+        items: [
+          {
+            id: Math.random(),
+            title: data.title,
+            dueDate: data.dueDate,
+            tags: data.tags ?? [],
+            linkUrl: data.linkUrl ?? null,
+            imageUrl: data.imageUrl ?? null,
+            goalId: data.goalId,
+          },
+          ...(old?.todos ?? []),
+        ],
+      }));
+      return { previousTodos };
+    },
     onSuccess: () => {
       showToast('할 일이 생성되었습니다.');
       queryClient.invalidateQueries({ queryKey: ['todos', 'list'] });
@@ -107,6 +165,12 @@ export const useDeleteTodo = (todoId?: number) => {
       }
       return fetchTodos.deleteTodo(todoId);
     },
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: ['todos', 'detail', todoId] });
+      const previousTodo = queryClient.getQueryData(['todos', 'detail', todoId]);
+      queryClient.setQueryData(['todos', 'detail', todoId], undefined);
+      return { previousTodo };
+    },
     onSuccess: () => {
       showToast('할 일이 삭제되었습니다.');
       queryClient.invalidateQueries({ queryKey: ['todos', 'list', {}] });
@@ -129,6 +193,16 @@ export const usePatchTodo = (todoId?: number) => {
         throw new Error('Todo id is required');
       }
       return fetchTodos.patchTodo(todoId, data);
+    },
+
+    onMutate: async (data: PatchTodoRequest) => {
+      await queryClient.cancelQueries({ queryKey: ['todos', 'detail', todoId] });
+      const previousTodo = queryClient.getQueryData(['todos', 'detail', todoId]);
+      queryClient.setQueryData(['todos', 'detail', todoId], (old: PatchTodoResponse) => ({
+        ...old,
+        ...data,
+      }));
+      return { previousTodo };
     },
 
     onSuccess: () => {
@@ -156,6 +230,15 @@ export const usePatchTodoFavorite = (todoId?: number) => {
       }
 
       return fetchTodos.patchTodoFavorite(todoId);
+    },
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: ['todos', 'detail', todoId] });
+      const previousTodo = queryClient.getQueryData(['todos', 'detail', todoId]);
+      queryClient.setQueryData(['todos', 'detail', todoId], (old: PatchTodoFavoriteResponse) => ({
+        ...old,
+        favorite: !old?.favorite,
+      }));
+      return { previousTodo };
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['todos', 'detail', todoId] });

--- a/src/shared/lib/mutations.ts
+++ b/src/shared/lib/mutations.ts
@@ -198,10 +198,13 @@ export const usePatchTodo = (todoId?: number) => {
     onMutate: async (data: PatchTodoRequest) => {
       await queryClient.cancelQueries({ queryKey: ['todos', 'detail', todoId] });
       const previousTodo = queryClient.getQueryData(['todos', 'detail', todoId]);
-      queryClient.setQueryData(['todos', 'detail', todoId], (old: PatchTodoResponse) => ({
-        ...old,
-        ...data,
-      }));
+      queryClient.setQueryData(['todos', 'detail', todoId], (old: PatchTodoResponse) => {
+        if (!old) return old;
+        return {
+          ...old,
+          ...data,
+        };
+      });
       return { previousTodo };
     },
 

--- a/src/shared/lib/mutations.ts
+++ b/src/shared/lib/mutations.ts
@@ -3,7 +3,7 @@ import { useRouter } from 'next/navigation';
 
 import { fetchGoals, PostGoalRequest } from './api/fetchGoals';
 import { fetchAuth } from './api';
-import { fetchTodos, PatchTodoRequest, PatchTodoRequestWithNull, PostTodoRequest } from './api/fetchTodos';
+import { fetchTodos, PatchTodoRequest, PostTodoRequest } from './api/fetchTodos';
 import { fetchUsers, PatchCurrentUserRequest, PatchCurrentUserPasswordRequest } from './api/fetchUsers';
 import { useToastStore } from '@/shared/stores/useToastStore';
 
@@ -124,7 +124,7 @@ export const usePatchTodo = (todoId?: number) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (data: PatchTodoRequestWithNull) => {
+    mutationFn: async (data: PatchTodoRequest) => {
       if (todoId === undefined) {
         throw new Error('Todo id is required');
       }

--- a/src/shared/types/api/schemas/api.types.ts
+++ b/src/shared/types/api/schemas/api.types.ts
@@ -669,25 +669,25 @@ export interface components {
              * Format: date-time
              * @description 마감일
              */
-            dueDate?: string;
+            dueDate?: string | null;
             /** @description 링크 URL */
-            linkUrl?: string;
+            linkUrl?: string | null;
             /** @description 이미지 URL */
-            imageUrl?: string;
+            imageUrl?: string | null;
             /**
              * @description 할일 출처 (MANUAL, GITHUB_ISSUE, GITHUB_PR)
-             * @enum {string}
+             * @enum {string|null}
              */
-            source?: "MANUAL" | "GITHUB_ISSUE" | "GITHUB_PR";
+            source?: "MANUAL" | "GITHUB_ISSUE" | "GITHUB_PR" | null;
             /**
              * Format: int64
              * @description 외부 소스 항목 ID
              */
-            sourceItemId?: number;
+            sourceItemId?: number | null;
             /** @description 상태 */
-            status?: string;
+            status?: string | null;
             /** @description 태그 이름 목록 */
-            tags?: string[];
+            tags?: (string | null)[] | null;
         };
         /** @description 목표 요약 정보 */
         GoalInfo: {
@@ -724,11 +724,11 @@ export interface components {
              * Format: date-time
              * @description 마감일
              */
-            dueDate?: string;
+            dueDate?: string | null;
             /** @description 이미지 URL */
-            imageUrl?: string;
+            imageUrl?: string | null;
             /** @description 링크 URL */
-            linkUrl?: string;
+            linkUrl?: string | null;
             /**
              * @description 할일 출처 (MANUAL, GITHUB_ISSUE, GITHUB_PR)
              * @enum {string}
@@ -738,12 +738,11 @@ export interface components {
              * Format: int64
              * @description 외부 소스 항목 ID (GitHub issue/PR 번호)
              */
-            sourceItemId?: number;
+            sourceItemId?: number | null;
             /** @description 상태 */
-            status?: string;
+            status?: string | null;
             /** @description 즐겨찾기 여부 */
             favorite: boolean;
-            /** @description 연결된 목표 정보 */
             goal: components["schemas"]["GoalInfo"];
             /**
              * Format: int64
@@ -782,9 +781,9 @@ export interface components {
             /** @description 노트 제목 */
             title: string;
             /** @description 노트 내용 */
-            content?: string;
+            content?: string | null;
             /** @description 링크 URL */
-            linkUrl?: string;
+            linkUrl?: string | null;
         };
         /** @description 노트 응답 */
         NoteResponse: {
@@ -811,9 +810,9 @@ export interface components {
             /** @description 노트 제목 */
             title: string;
             /** @description 노트 내용 */
-            content?: string;
+            content?: string | null;
             /** @description 링크 URL */
-            linkUrl?: string;
+            linkUrl?: string | null;
             /**
              * @description 할일 출처 (MANUAL, GITHUB_ISSUE, GITHUB_PR)
              * @enum {string}
@@ -823,9 +822,9 @@ export interface components {
              * Format: int64
              * @description 외부 소스 항목 ID
              */
-            sourceItemId?: number;
+            sourceItemId?: number | null;
             /** @description 상태 */
-            status?: string;
+            status?: string | null;
             /**
              * Format: date-time
              * @description 생성일시
@@ -836,7 +835,6 @@ export interface components {
              * @description 수정일시
              */
             updatedAt: string;
-            /** @description 연결된 할일 정보 */
             todo: components["schemas"]["TodoInfo"];
         };
         /** @description 할일 정보 */
@@ -891,9 +889,9 @@ export interface components {
              * Format: int64
              * @description GitHub 리포지토리 ID
              */
-            repositoryId?: number;
+            repositoryId?: number | null;
             /** @description GitHub 리포지토리 전체 이름 (owner/repo) */
-            repositoryFullName?: string;
+            repositoryFullName?: string | null;
             /**
              * Format: int64
              * @description 사용자 ID
@@ -941,7 +939,7 @@ export interface components {
             /** @description 닉네임 */
             nickname: string;
             /** @description 프로필 이미지 URL */
-            profileImageUrl?: string;
+            profileImageUrl?: string | null;
             /**
              * @description 로그인 제공자 (LOCAL, GOOGLE, GITHUB)
              * @enum {string}
@@ -957,7 +955,7 @@ export interface components {
         /** @description 토큰 갱신 요청 */
         RefreshRequest: {
             /** @description 리프레시 토큰 */
-            refreshToken?: string;
+            refreshToken?: string | null;
         };
         /** @description 토큰 갱신 응답 */
         RefreshResponse: {
@@ -981,9 +979,9 @@ export interface components {
         /** @description 사용자 정보 수정 요청 */
         UpdateUserRequest: {
             /** @description 닉네임 */
-            nickname?: string;
+            nickname?: string | null;
             /** @description 프로필 이미지 URL */
-            profileImageUrl?: string;
+            profileImageUrl?: string | null;
         };
         /** @description 사용자 정보 응답 */
         UserResponse: {
@@ -997,7 +995,7 @@ export interface components {
             /** @description 닉네임 */
             nickname: string;
             /** @description 프로필 이미지 URL */
-            profileImageUrl?: string;
+            profileImageUrl?: string | null;
             /**
              * @description 로그인 제공자 (LOCAL, GOOGLE, GITHUB)
              * @enum {string}
@@ -1018,20 +1016,20 @@ export interface components {
         /** @description 할일 수정 요청 */
         UpdateTodoRequest: {
             /** @description 할일 제목 */
-            title?: string;
+            title?: string | null;
             /** @description 완료 여부 */
-            done?: boolean;
+            done?: boolean | null;
             /**
              * Format: date-time
              * @description 마감일
              */
-            dueDate?: string;
+            dueDate?: string | null;
             /** @description 태그 이름 목록 */
-            tags?: string[];
+            tags?: (string | null)[] | null;
             /** @description 링크 URL */
-            linkUrl?: string;
+            linkUrl?: string | null;
             /** @description 이미지 URL */
-            imageUrl?: string;
+            imageUrl?: string | null;
         };
         /** @description 알림 응답 */
         NotificationResponse: {
@@ -1058,11 +1056,11 @@ export interface components {
         /** @description 노트 수정 요청 */
         UpdateNoteRequest: {
             /** @description 노트 제목 */
-            title?: string;
+            title?: string | null;
             /** @description 노트 내용 */
-            content?: string;
+            content?: string | null;
             /** @description 링크 URL */
-            linkUrl?: string;
+            linkUrl?: string | null;
         };
         /** @description 목표 수정 요청 */
         UpdateGoalRequest: {
@@ -1112,7 +1110,7 @@ export interface components {
              * Format: int64
              * @description 다음 페이지 커서 (마지막 페이지면 null)
              */
-            nextCursor?: number;
+            nextCursor?: number | null;
             /** @description 다음 페이지 존재 여부 */
             hasMore: boolean;
             /**
@@ -1160,7 +1158,6 @@ export interface components {
         NoteListResponse: {
             /** @description 노트 목록 */
             notes: components["schemas"]["NoteListItem"][];
-            /** @description 페이지 정보 */
             pageInfo: components["schemas"]["PageInfo"];
         };
         /** @description 페이지 정보 */
@@ -1194,7 +1191,7 @@ export interface components {
              * Format: int64
              * @description 다음 페이지 커서 (마지막 페이지면 null)
              */
-            nextCursor?: number;
+            nextCursor?: number | null;
             /** @description 다음 페이지 존재 여부 */
             hasMore: boolean;
             /**
@@ -1221,9 +1218,9 @@ export interface components {
              * Format: int64
              * @description GitHub 리포지토리 ID
              */
-            repositoryId?: number;
+            repositoryId?: number | null;
             /** @description GitHub 리포지토리 전체 이름 (owner/repo) */
-            repositoryFullName?: string;
+            repositoryFullName?: string | null;
             /**
              * Format: int64
              * @description 사용자 ID
@@ -1279,7 +1276,7 @@ export interface components {
         /** @description 회원 탈퇴 요청 */
         DeleteUserRequest: {
             /** @description 비밀번호 (로컬 로그인 사용자만 필수) */
-            password?: string;
+            password?: string | null;
         };
     };
     responses: never;


### PR DESCRIPTION
## 무엇을 변경했나요?

- [x] todo -> done 으로 넘길 때 낙관적 업데이트 필요
- [x] Todoform 에러 처리 및 낙관적 업데이트 필요
- [x] mutateAsync의 에러 처리 부재
- [x] route.ts 경로 허용 범위 지정하기
- [x] 리프레쉬토큰 확인
- [x] api 타입 수정


## 왜 이렇게 했나요?
1. 기존 낙관적 업데이트가 전혀 되어있지 않아 onMutate로 낙관적 업데이트 처리 
2. Todoform ApiError로 에러 처리 
3. route 경로 수정하면서 리프레쉬 토큰 수정 
- `const ALLOWED_PATH_PREFIXES = ['auth/', 'todos', 'goals', 'notes', 'notifications', 'tags', 'users/me'] as const;` <- 허용된경로
- 



## 리뷰어가 특히 봐줬으면 하는 부분

- 낙관적 업데이트 부분

## 스크린샷 (UI 변경 시)

https://github.com/user-attachments/assets/352110d9-d47f-4463-9567-9ff35c40f8c9


## 다음에 할 것 
- [ ] 로고 변경
- [ ] 쿼리 키 파일 생성 
- [ ] 사이드바 애니메이션 처리 
- [ ] 전체 반응형 확인