### PR TITLE
fix: 소셜 로그인 환경별 리다이렉트 처리 및 프록시 경로 허용 추가

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -32,13 +32,21 @@ export default function LoginPage() {
     }
   };
   const handleGithubLogin = async () => {
-    const { loginUrl } = await fetchAuth.getGithubAuthorizeUrlByEnv();
-    if (loginUrl) window.location.href = loginUrl;
+    try {
+      const { loginUrl } = await fetchAuth.getGithubAuthorizeUrlByEnv();
+      if (loginUrl) window.location.href = loginUrl;
+    } catch (error) {
+      console.error('GitHub 로그인 URL 요청 실패:', error);
+    }
   };
 
   const handleGoogleLogin = async () => {
-    const data = await fetchAuth.getGoogleAuthorizeUrlByEnv();
-    if (data.loginUrl) window.location.href = data.loginUrl;
+    try {
+      const data = await fetchAuth.getGoogleAuthorizeUrlByEnv();
+      if (data.loginUrl) window.location.href = data.loginUrl;
+    } catch (error) {
+      console.error('Google 로그인 URL 요청 실패:', error);
+    }
   };
   return (
     <main className="flex min-h-screen items-center justify-center py-20">
@@ -70,12 +78,15 @@ export default function LoginPage() {
               onChange={(e) => setPassword(e.target.value)}
             />
           </FormField>
-          <Button type="submit" className="mt-8 h-14 w-full bg-[#00C87F] hover:bg-[#00C87F]/90" disabled={!email || !password}>
+          <Button
+            type="submit"
+            className="mt-8 h-14 w-full bg-[#00C87F] hover:bg-[#00C87F]/90"
+            disabled={!email || !password}
+          >
             로그인하기
           </Button>
         </form>
 
-        
         <div className="mt-6 flex h-6 w-full items-center justify-center gap-2 text-sm">
           <span className="text-base leading-6 font-medium text-[#333333]">베어로그가 처음이신가요?</span>
           <Link href="/signup" className="text-base leading-6 font-semibold text-[#008354]">

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -9,9 +9,11 @@ import Input from '@/shared/components/Input';
 import Button from '@/shared/components/Button';
 import Image from 'next/image';
 import { fetchAuth } from '@/shared/lib/api/fetchAuth'; // 추가
+import { useToastStore } from '@/shared/stores/useToastStore';
 
 export default function LoginPage() {
   const router = useRouter();
+  const { showToast } = useToastStore();
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -37,15 +39,17 @@ export default function LoginPage() {
       if (loginUrl) window.location.href = loginUrl;
     } catch (error) {
       console.error('GitHub 로그인 URL 요청 실패:', error);
+      showToast('소셜 로그인에 실패했습니다. 다시 시도해주세요.', 'fail');
     }
   };
 
   const handleGoogleLogin = async () => {
     try {
-      const data = await fetchAuth.getGoogleAuthorizeUrlByEnv();
-      if (data.loginUrl) window.location.href = data.loginUrl;
+      const { loginUrl } = await fetchAuth.getGoogleAuthorizeUrlByEnv();
+      if (loginUrl) window.location.href = loginUrl;
     } catch (error) {
       console.error('Google 로그인 URL 요청 실패:', error);
+      showToast('소셜 로그인에 실패했습니다. 다시 시도해주세요.', 'fail');
     }
   };
   return (

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -9,9 +9,11 @@ import Button from '@/shared/components/Button';
 import FormField from '@/shared/components/FormField';
 import { validateEmail, validatePassword, validatePasswordConfirm } from '@/shared/lib/validation';
 import { fetchAuth } from '@/shared/lib/api/fetchAuth';
+import { useToastStore } from '@/shared/stores/useToastStore';
 
 export default function SignupPage() {
   const router = useRouter();
+  const { showToast } = useToastStore();
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -35,29 +37,31 @@ export default function SignupPage() {
     try {
       await fetchAuth.postSignup({ nickname: name, email, password });
 
-      alert('회원가입 성공!');
+      showToast('회원가입이 완료되었습니다.', 'success');
       router.push('/login');
     } catch (error) {
       console.error(error);
-      alert('회원가입 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      showToast('회원가입 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.', 'fail');
     }
   };
 
   const handleGithubLogin = async () => {
     try {
-      const data = await fetchAuth.getGithubAuthorizeUrlByEnv();
-      if (data.loginUrl) window.location.href = data.loginUrl;
+      const { loginUrl } = await fetchAuth.getGithubAuthorizeUrlByEnv();
+      if (loginUrl) window.location.href = loginUrl;
     } catch (error) {
       console.error('GitHub 로그인 URL 요청 실패:', error);
+      showToast('소셜 로그인에 실패했습니다. 다시 시도해주세요.', 'fail');
     }
   };
 
   const handleGoogleLogin = async () => {
     try {
-      const data = await fetchAuth.getGoogleAuthorizeUrlByEnv();
-      if (data.loginUrl) window.location.href = data.loginUrl;
+      const { loginUrl } = await fetchAuth.getGoogleAuthorizeUrlByEnv();
+      if (loginUrl) window.location.href = loginUrl;
     } catch (error) {
       console.error('Google 로그인 URL 요청 실패:', error);
+      showToast('소셜 로그인에 실패했습니다. 다시 시도해주세요.', 'fail');
     }
   };
 

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -44,13 +44,21 @@ export default function SignupPage() {
   };
 
   const handleGithubLogin = async () => {
-    const data = await fetchAuth.getGithubAuthorizeUrl();
-    if (data.loginUrl) window.location.href = data.loginUrl;
+    try {
+      const data = await fetchAuth.getGithubAuthorizeUrlByEnv();
+      if (data.loginUrl) window.location.href = data.loginUrl;
+    } catch (error) {
+      console.error('GitHub 로그인 URL 요청 실패:', error);
+    }
   };
 
   const handleGoogleLogin = async () => {
-    const data = await fetchAuth.getGoogleAuthorizeUrl();
-    if (data.loginUrl) window.location.href = data.loginUrl;
+    try {
+      const data = await fetchAuth.getGoogleAuthorizeUrlByEnv();
+      if (data.loginUrl) window.location.href = data.loginUrl;
+    } catch (error) {
+      console.error('Google 로그인 URL 요청 실패:', error);
+    }
   };
 
   return (

--- a/src/app/api/proxy/[...endpoint]/route.ts
+++ b/src/app/api/proxy/[...endpoint]/route.ts
@@ -17,7 +17,7 @@ const REFRESH_ENDPOINT = 'auth/refresh';
 const FORWARDED_REQUEST_HEADERS = ['accept', 'content-type'] as const;
 const FORWARDED_RESPONSE_HEADERS = ['content-type', 'location'] as const;
 
-const ALLOWED_PATH_PREFIXES = ['auth/', 'todos', 'goals', 'notes', 'notifications', 'tags', 'users/me'] as const;
+const ALLOWED_PATH_PREFIXES = ['auth/', 'dev/auth/', 'todos', 'goals', 'notes', 'notifications', 'tags', 'users/me'] as const;
 
 type ProxyRouteContext = {
   params: Promise<{ endpoint: string[] }>;
@@ -28,7 +28,7 @@ const isAllowedPath = (pathname: string) => {
 };
 
 const shouldSyncAuthCookies = (pathname: string) => {
-  return pathname.startsWith('auth/');
+  return pathname.startsWith('auth/') || pathname.startsWith('dev/auth/');
 };
 
 const buildUpstreamHeaders = (request: NextRequest, accessToken?: string) => {
@@ -76,7 +76,7 @@ const syncAuthCookies = async (pathname: string, response: Response, nextRespons
     return;
   }
 
-  if (pathname === 'auth/logout') {
+  if (pathname === 'auth/logout' || pathname === 'dev/auth/logout') {
     nextResponse.cookies.delete(ACCESS_TOKEN_COOKIE);
     nextResponse.cookies.delete(REFRESH_TOKEN_COOKIE);
     return;


### PR DESCRIPTION
## 무엇을 변경했나요?

- 회원가입 소셜 로그인 `getGithubAuthorizeUrlByEnv` / `getGoogleAuthorizeUrlByEnv` 로 변경
- 프록시 허용 경로에 `dev/auth/` 추가
- 소셜 로그인 핸들러 try/catch 추가

## 왜 이렇게 했나요?

- 회원가입 페이지 소셜 로그인이 개발 환경에서도 배포 사이트로 리다이렉트되는 문제 해결

## 리뷰어가 특히 봐줬으면 하는 부분

- [ ] (예: 이 로직이 엣지케이스를 잘 처리하는지)

## 스크린샷 (UI 변경 시)
