### PR TITLE
[refactor/feedback] 강사님 피드백 반영

### DIFF
--- a/src/features/note/components/EllipsisButton/index.tsx
+++ b/src/features/note/components/EllipsisButton/index.tsx
@@ -7,7 +7,6 @@ import { DropdownList } from '@/shared/components/Dropdown';
 import { DropdownItemType } from '@/shared/types/types';
 import { useModalStore } from '@/shared/stores/useModalStore';
 import { PopupModal } from '@/shared/components/Modal/PopupModal';
-import { useToastStore } from '@/shared/stores/useToastStore';
 import { useDeleteNote } from '@/shared/lib/query/mutations';
 
 interface EllipsisButtonProps {
@@ -20,11 +19,8 @@ export default function EllipsisButton({ items, noteId, goalId }: EllipsisButton
   const [isOpen, setIsOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const { openModal } = useModalStore();
-  const { showToast } = useToastStore();
 
-  const { mutate: handleDelete } = useDeleteNote(noteId, goalId, {
-    onError: () => showToast('노트 삭제에 실패했습니다', 'fail'),
-  });
+  const { mutate: handleDelete } = useDeleteNote(noteId, goalId);
 
   useOnClickOutside(ref, () => setIsOpen(false));
 

--- a/src/features/note/components/NoteCreateClient/index.tsx
+++ b/src/features/note/components/NoteCreateClient/index.tsx
@@ -10,11 +10,7 @@ import { useToastStore } from '@/shared/stores/useToastStore';
 import { useRouter } from 'next/navigation';
 import DraftNoteToast from '@/features/note/components/DraftNoteToast';
 import { useBreakpoint } from '@/shared/hooks/useBreakPoint';
-import { useEditor } from '@tiptap/react';
-import StarterKit from '@tiptap/starter-kit';
-import Underline from '@tiptap/extension-underline';
-import TextAlign from '@tiptap/extension-text-align';
-import Placeholder from '@tiptap/extension-placeholder';
+import { useNoteEditor } from '@/features/note/hooks/useNoteEditor';
 import EditorToolbar from '@/features/note/components/NoteEditor/EditorToolbar';
 import { createPortal } from 'react-dom';
 import { TodoResponse } from '@/shared/lib/api/fetchTodos';
@@ -119,19 +115,7 @@ export default function NoteCreateClient({ goal, todo }: NoteCreateClientProps) 
     return () => setSlot(null);
   }, [breakpoint, handleSaveDraft, handleSubmit, showDraftToast, handleToastLoad, handleCloseToast, setSlot]);
 
-  const editor = useEditor({
-    extensions: [
-      StarterKit,
-      Underline,
-      TextAlign.configure({ types: ['heading', 'paragraph'] }),
-      Placeholder.configure({ placeholder: '이 곳을 통해 노트 작성을 시작해주세요' }),
-    ],
-    content,
-    immediatelyRender: false,
-    onUpdate: ({ editor }) => {
-      setContent(editor.getHTML());
-    },
-  });
+  const editor = useNoteEditor({ content, onContentChange: setContent });
 
   return (
     <div className="mx-auto flex h-full w-full max-w-[768px] flex-col">

--- a/src/features/note/components/NoteCreateClient/index.tsx
+++ b/src/features/note/components/NoteCreateClient/index.tsx
@@ -39,11 +39,7 @@ export default function NoteCreateClient({ goal, todo }: NoteCreateClientProps) 
   const { showToast } = useToastStore();
   const setSlot = useMobileHeaderStore((s) => s.setSlot);
 
-  const { mutate: createNote, isPending } = usePostNote({
-    onError: (error) => {
-      showToast(error.message || '노트 작성에 실패했습니다', 'fail');
-    },
-  });
+  const { mutate: createNote, isPending } = usePostNote();
 
   const breakpoint = useBreakpoint();
 
@@ -96,7 +92,7 @@ export default function NoteCreateClient({ goal, todo }: NoteCreateClientProps) 
         <div className="relative">
           <button
             type="button"
-            className="text-bearlog-500 hover:text-bearlog-600 cursor-pointer px-1.5 transition-all duration-200 font-semibold text-sm"
+            className="text-bearlog-500 hover:text-bearlog-600 cursor-pointer px-1.5 text-sm font-semibold transition-all duration-200"
             onClick={handleSaveDraft}
           >
             임시저장
@@ -105,7 +101,7 @@ export default function NoteCreateClient({ goal, todo }: NoteCreateClientProps) 
         </div>
         <button
           type="button"
-          className="cursor-pointer px-1.5 text-gray-500 transition-all duration-200 hover:text-gray-600 font-semibold text-sm"
+          className="cursor-pointer px-1.5 text-sm font-semibold text-gray-500 transition-all duration-200 hover:text-gray-600"
           onClick={handleSubmit}
         >
           등록

--- a/src/features/note/components/NoteDetailClient/index.tsx
+++ b/src/features/note/components/NoteDetailClient/index.tsx
@@ -13,14 +13,20 @@ interface NoteDetailClientProps {
 }
 
 export default function NoteDetailClient({ noteId, goalId }: NoteDetailClientProps) {
-  const { data: note } = useQuery(noteQueries.detail(noteId));
+  const { data: note, isLoading: isNoteLoading, isError: isNoteError } = useQuery(noteQueries.detail(noteId));
   const { data: goal } = useQuery(goalQueries.detail(goalId));
   const { data: todo } = useQuery({
     ...todoQueries.detail(note?.todoId ?? 0),
     enabled: note?.todoId != null,
   });
 
-  if (!note) return null;
+  if (isNoteLoading) {
+    return <p className="p-10 text-center text-sm text-gray-500">노트를 불러오는 중...</p>;
+  }
+
+  if (isNoteError || !note) {
+    return <p className="p-10 text-center text-sm text-gray-500">노트를 불러오는 데 실패했습니다.</p>;
+  }
 
   const tags = mapNoteTagsFromSource({
     source: note.source,

--- a/src/features/note/components/NoteEditClient/index.tsx
+++ b/src/features/note/components/NoteEditClient/index.tsx
@@ -12,11 +12,7 @@ import DraftNoteToast from '@/features/note/components/DraftNoteToast';
 import { useToastStore } from '@/shared/stores/useToastStore';
 import { useMobileHeaderStore } from '@/shared/stores/useMobileHeaderStore';
 import { useBreakpoint } from '@/shared/hooks/useBreakPoint';
-import { useEditor } from '@tiptap/react';
-import StarterKit from '@tiptap/starter-kit';
-import Underline from '@tiptap/extension-underline';
-import TextAlign from '@tiptap/extension-text-align';
-import Placeholder from '@tiptap/extension-placeholder';
+import { useNoteEditor } from '@/features/note/hooks/useNoteEditor';
 import EditorToolbar from '@/features/note/components/NoteEditor/EditorToolbar';
 import { createPortal } from 'react-dom';
 import { usePatchNote } from '@/shared/lib/query/mutations';
@@ -57,19 +53,7 @@ export default function NoteEditClient({ noteId, goalId }: NoteEditClientProps) 
 
   const breakpoint = useBreakpoint();
 
-  const editor = useEditor({
-    extensions: [
-      StarterKit,
-      Underline,
-      TextAlign.configure({ types: ['heading', 'paragraph'] }),
-      Placeholder.configure({ placeholder: '이 곳을 통해 노트 작성을 시작해주세요' }),
-    ],
-    content,
-    immediatelyRender: false,
-    onUpdate: ({ editor }) => {
-      setContent(editor.getHTML());
-    },
-  });
+  const editor = useNoteEditor({ content, onContentChange: setContent });
 
   const handleSaveDraft = useCallback(() => {
     try {

--- a/src/features/note/components/NoteEditClient/index.tsx
+++ b/src/features/note/components/NoteEditClient/index.tsx
@@ -47,9 +47,7 @@ export default function NoteEditClient({ noteId, goalId }: NoteEditClientProps) 
     },
   });
 
-  const { mutate: patchNote, isPending } = usePatchNote(noteId, goalId, {
-    onError: () => showToast('노트 수정에 실패했습니다', 'fail'),
-  });
+  const { mutate: patchNote, isPending } = usePatchNote(noteId, goalId);
 
   const breakpoint = useBreakpoint();
 

--- a/src/features/note/components/NoteItem/index.tsx
+++ b/src/features/note/components/NoteItem/index.tsx
@@ -17,7 +17,7 @@ export default function NoteItem({ note, goalId }: { note: Note; goalId: string 
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2 md:gap-4">
             <Image src={noteIcon} sizes="32" alt="노트 아이콘" className="md:h-10 md:w-10" />
-            <h1 className="line-clamp-1 text-sm font-semibold text-[#1E293B] md:text-xl">{note.title}</h1>
+            <h3 className="line-clamp-1 text-sm font-semibold text-[#1E293B] md:text-xl">{note.title}</h3>
           </div>
           <EllipsisButton
             items={[

--- a/src/features/note/components/NoteListClient/index.tsx
+++ b/src/features/note/components/NoteListClient/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { noteQueries, goalQueries } from '@/shared/lib/query/queryKeys';
 import NoteItem from '@/features/note/components/NoteItem';
@@ -13,10 +14,13 @@ interface NoteListClientProps {
   goalId: number;
   search?: string;
   sort?: 'LATEST' | 'OLDEST';
+  page: number;
+  onPageChange: (page: number) => void;
 }
 
-export default function NoteListClient({ goalId, search, sort }: NoteListClientProps) {
-  const [page, setPage] = useState(1);
+export default function NoteListClient({ goalId, search, sort, page, onPageChange }: NoteListClientProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
 
   const { data: goal } = useQuery(goalQueries.detail(goalId));
   const { data: noteList } = useQuery({
@@ -27,6 +31,14 @@ export default function NoteListClient({ goalId, search, sort }: NoteListClientP
   const notes = (noteList?.notes ?? []).filter((note) => note.id != null);
   const currentPage = (noteList?.pageInfo?.page ?? 0) + 1;
   const totalPages = noteList?.pageInfo?.totalPages ?? 1;
+
+  useEffect(() => {
+    if (notes.length === 0 && page > 1 && noteList !== undefined) {
+      const next = new URLSearchParams(searchParams.toString());
+      next.set('page', String(page - 1));
+      router.replace(`?${next.toString()}`);
+    }
+  }, [notes.length, page, noteList, router, searchParams]);
 
   return (
     <>
@@ -55,7 +67,7 @@ export default function NoteListClient({ goalId, search, sort }: NoteListClientP
 
       {notes.length > 0 && (
         <div className="mt-6 flex justify-center">
-          <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={setPage} />
+          <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={onPageChange} />
         </div>
       )}
     </>

--- a/src/features/note/components/NoteListClient/index.tsx
+++ b/src/features/note/components/NoteListClient/index.tsx
@@ -17,14 +17,6 @@ interface NoteListClientProps {
 
 export default function NoteListClient({ goalId, search, sort }: NoteListClientProps) {
   const [page, setPage] = useState(1);
-  const [prevSearch, setPrevSearch] = useState(search);
-  const [prevSort, setPrevSort] = useState(sort);
-
-  if (search !== prevSearch || sort !== prevSort) {
-    setPrevSearch(search);
-    setPrevSort(sort);
-    setPage(1);
-  }
 
   const { data: goal } = useQuery(goalQueries.detail(goalId));
   const { data: noteList } = useQuery({

--- a/src/features/note/components/NoteListContainer/index.tsx
+++ b/src/features/note/components/NoteListContainer/index.tsx
@@ -17,7 +17,7 @@ export default function NoteListContainer({ goalId }: NoteListContainerProps) {
 
   const submittedSearch = searchParams.get('search') ?? '';
   const sort = (searchParams.get('sort') as 'LATEST' | 'OLDEST') ?? 'LATEST';
-  const page = Number(searchParams.get('page') ?? '1');
+  const page = Number(searchParams.get('page') ?? '1') || 1;
 
   const updateParams = (params: Record<string, string>) => {
     const next = new URLSearchParams(searchParams.toString());

--- a/src/features/note/components/NoteListContainer/index.tsx
+++ b/src/features/note/components/NoteListContainer/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import NoteListHeader from '@/features/note/components/NoteListHeader';
 import NoteListClient from '@/features/note/components/NoteListClient';
 
@@ -10,25 +10,42 @@ interface NoteListContainerProps {
 }
 
 export default function NoteListContainer({ goalId }: NoteListContainerProps) {
-  const [searchInput, setSearchInput] = useState('');
-  const [submittedSearch, setSubmittedSearch] = useState('');
-  const [sort, setSort] = useState<'LATEST' | 'OLDEST'>('LATEST');
   const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [searchInput, setSearchInput] = useState('');
+
+  const submittedSearch = searchParams.get('search') ?? '';
+  const sort = (searchParams.get('sort') as 'LATEST' | 'OLDEST') ?? 'LATEST';
+  const page = Number(searchParams.get('page') ?? '1');
+
+  const updateParams = (params: Record<string, string>) => {
+    const next = new URLSearchParams(searchParams.toString());
+    Object.entries(params).forEach(([key, value]) => next.set(key, value));
+    router.replace(`?${next.toString()}`);
+  };
+
   return (
     <>
       <NoteListHeader
         search={searchInput}
         onSearchChange={setSearchInput}
-        onSearch={() => setSubmittedSearch(searchInput)}
+        onSearch={() => updateParams({ search: searchInput, page: '1' })}
         sort={sort}
         onSortChange={(v) => {
           if (v === 'LATEST' || v === 'OLDEST') {
-            setSort(v);
+            updateParams({ sort: v, page: '1' });
           }
         }}
         onCreateNote={() => router.push(`/goal/${goalId}/note/create`)}
       />
-      <NoteListClient key={`${submittedSearch}-${sort}`} goalId={goalId} search={submittedSearch} sort={sort} />
+      <NoteListClient
+        goalId={goalId}
+        search={submittedSearch}
+        sort={sort}
+        page={page}
+        onPageChange={(p) => updateParams({ page: String(p) })}
+      />
     </>
   );
 }

--- a/src/features/note/components/NoteListContainer/index.tsx
+++ b/src/features/note/components/NoteListContainer/index.tsx
@@ -28,7 +28,7 @@ export default function NoteListContainer({ goalId }: NoteListContainerProps) {
         }}
         onCreateNote={() => router.push(`/goal/${goalId}/note/create`)}
       />
-      <NoteListClient goalId={goalId} search={submittedSearch} sort={sort} />
+      <NoteListClient key={`${submittedSearch}-${sort}`} goalId={goalId} search={submittedSearch} sort={sort} />
     </>
   );
 }

--- a/src/features/note/components/Pagination/index.tsx
+++ b/src/features/note/components/Pagination/index.tsx
@@ -1,39 +1,30 @@
-import { ChevronLeftIcon, ChevronRightIcon, ChevronsLeftIcon, ChevronsRightIcon } from 'lucide-react';
+import { ChevronLeftIcon, ChevronRightIcon, ChevronsLeftIcon, ChevronsRightIcon, LucideIcon } from 'lucide-react';
 
 // ---- 서브 컴포넌트 ----
 
 interface NavButtonProps {
+  icon: LucideIcon;
   disabled?: boolean;
   onClick?: () => void;
+  'aria-label': string;
 }
 
 const btnBase = 'flex-row-center h-6 w-6 cursor-pointer rounded-[5px] p-0.5';
 const enabledStyle = 'bg-primary-500-10 text-primary-500';
 const disabledStyle = 'bg-gray-200 text-gray-300';
 
-const ChevronLeft = ({ disabled, onClick }: NavButtonProps) => (
-  <button className={`${btnBase} ${disabled ? disabledStyle : enabledStyle}`} onClick={onClick} disabled={disabled}>
-    <ChevronLeftIcon className={`${disabled ? 'text-gray-300' : 'text-primary-500'} h-full w-full`} />
-  </button>
-);
-
-const ChevronRight = ({ disabled, onClick }: NavButtonProps) => (
-  <button className={`${btnBase} ${disabled ? disabledStyle : enabledStyle}`} onClick={onClick} disabled={disabled}>
-    <ChevronRightIcon className={`${disabled ? 'text-gray-300' : 'text-primary-500'} h-full w-full`} />
-  </button>
-);
-
-const ChevronsLeft = ({ disabled, onClick }: NavButtonProps) => (
-  <button className={`${btnBase} ${disabled ? disabledStyle : enabledStyle}`} onClick={onClick} disabled={disabled}>
-    <ChevronsLeftIcon className={`${disabled ? 'text-gray-300' : 'text-primary-500'} h-full w-full`} />
-  </button>
-);
-
-const ChevronsRight = ({ disabled, onClick }: NavButtonProps) => (
-  <button className={`${btnBase} ${disabled ? disabledStyle : enabledStyle}`} onClick={onClick} disabled={disabled}>
-    <ChevronsRightIcon className={`${disabled ? 'text-gray-300' : 'text-primary-500'} h-full w-full`} />
-  </button>
-);
+const NavButton = ({ icon: Icon, disabled, onClick, 'aria-label': ariaLabel }: NavButtonProps) => {
+  return (
+    <button
+      className={`${btnBase} ${disabled ? disabledStyle : enabledStyle}`}
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+    >
+      <Icon className={`${disabled ? 'text-gray-300' : 'text-primary-500'} h-full w-full`} />
+    </button>
+  );
+};
 
 interface PageButtonProps {
   page: number | string;
@@ -113,8 +104,18 @@ const Pagination = ({ currentPage, totalPages, onPageChange }: PaginationProps) 
 
   return (
     <div className="inline-flex items-center gap-3">
-      <ChevronsLeft disabled={currentPage === 1} onClick={() => onPageChange(1)} />
-      <ChevronLeft disabled={currentPage === 1} onClick={() => onPageChange(currentPage - 1)} />
+      <NavButton
+        icon={ChevronsLeftIcon}
+        disabled={currentPage === 1}
+        onClick={() => onPageChange(1)}
+        aria-label="첫 페이지"
+      />
+      <NavButton
+        icon={ChevronLeftIcon}
+        disabled={currentPage === 1}
+        onClick={() => onPageChange(currentPage - 1)}
+        aria-label="이전 페이지"
+      />
 
       {getPages().map((page, idx) => (
         <PageButton
@@ -126,8 +127,18 @@ const Pagination = ({ currentPage, totalPages, onPageChange }: PaginationProps) 
         />
       ))}
 
-      <ChevronRight disabled={currentPage === totalPages} onClick={() => onPageChange(currentPage + 1)} />
-      <ChevronsRight disabled={currentPage === totalPages} onClick={() => onPageChange(totalPages)} />
+      <NavButton
+        icon={ChevronRightIcon}
+        disabled={currentPage === totalPages}
+        onClick={() => onPageChange(currentPage + 1)}
+        aria-label="다음 페이지"
+      />
+      <NavButton
+        icon={ChevronsRightIcon}
+        disabled={currentPage === totalPages}
+        onClick={() => onPageChange(totalPages)}
+        aria-label="마지막 페이지"
+      />
     </div>
   );
 };

--- a/src/features/note/hooks/useNoteEditor.ts
+++ b/src/features/note/hooks/useNoteEditor.ts
@@ -1,0 +1,28 @@
+import { useEditor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import Underline from '@tiptap/extension-underline';
+import TextAlign from '@tiptap/extension-text-align';
+import Placeholder from '@tiptap/extension-placeholder';
+
+interface UseNoteEditorOptions {
+  content: string;
+  onContentChange: (html: string) => void;
+}
+
+export function useNoteEditor({ content, onContentChange }: UseNoteEditorOptions) {
+  return useEditor({
+    extensions: [
+      StarterKit,
+      Underline,
+      TextAlign.configure({ types: ['heading', 'paragraph'] }),
+      Placeholder.configure({
+        placeholder: '이 곳을 통해 노트 작성을 시작해주세요',
+      }),
+    ],
+    content,
+    immediatelyRender: false,
+    onUpdate: ({ editor }) => {
+      onContentChange(editor.getHTML());
+    },
+  });
+}

--- a/src/shared/lib/query/mutations.ts
+++ b/src/shared/lib/query/mutations.ts
@@ -344,18 +344,20 @@ export const usePostLogout = () => {
 };
 
 // note
-export const usePostNote = (callbacks?: { onError: (error: Error) => void }) => {
+export const usePostNote = () => {
   const queryClient = useQueryClient();
+  const { showToast } = useToastStore();
 
   return useMutation({
     mutationFn: fetchNotes.postNote,
     onSuccess: (response) => {
       if (!response.id || !response.goalId) {
         console.error('[usePostNote] Unexpected API response: missing id or goalId', response);
-        callbacks?.onError?.(new Error('노트 작성에 실패했습니다.'));
+        showToast('노트 작성에 실패했습니다.', 'fail');
         return;
       }
 
+      showToast('노트가 작성되었습니다.');
       queryClient.setQueryData(noteQueries.detail(response.id).queryKey, response);
       queryClient.invalidateQueries({
         queryKey: noteKeys.lists(),
@@ -363,8 +365,8 @@ export const usePostNote = (callbacks?: { onError: (error: Error) => void }) => 
 
       window.location.href = `/goal/${response.goalId}/note/${response.id}`;
     },
-    onError: (error) => {
-      if (callbacks?.onError) callbacks.onError(error);
+    onError: () => {
+      showToast('노트 작성에 실패했습니다.', 'fail');
     },
   });
 };

--- a/src/shared/lib/query/mutations.ts
+++ b/src/shared/lib/query/mutations.ts
@@ -369,8 +369,9 @@ export const usePostNote = (callbacks?: { onError: (error: Error) => void }) => 
   });
 };
 
-export const usePatchNote = (noteId: number, goalId: number, callbacks?: { onError?: (error: Error) => void }) => {
+export const usePatchNote = (noteId: number, goalId: number) => {
   const queryClient = useQueryClient();
+  const { showToast } = useToastStore();
 
   return useMutation({
     mutationFn: (body: PatchNoteRequest) => fetchNotes.patchNote(noteId, body),
@@ -379,7 +380,7 @@ export const usePatchNote = (noteId: number, goalId: number, callbacks?: { onErr
       queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
       window.location.href = `/goal/${goalId}/note/${noteId}`;
     },
-    onError: (error) => callbacks?.onError?.(error),
+    onError: () => showToast('노트 수정에 실패했습니다', 'fail'),
   });
 };
 
@@ -405,7 +406,7 @@ export const useDeleteNote = (noteId: number, goalId: number) => {
       router.push(`/goal/${goalId}/note?page=${page}`);
     },
     onError: () => {
-      showToast('노트 삭제에 실패했습니다', 'fail')
+      showToast('노트 삭제에 실패했습니다', 'fail');
     },
   });
 };

--- a/src/shared/lib/query/mutations.ts
+++ b/src/shared/lib/query/mutations.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import { fetchAuth } from '../api';
 import { fetchGoals, GoalListResponse, PatchGoalResponse, PostGoalRequest } from '../api/fetchGoals';
@@ -383,13 +383,16 @@ export const usePatchNote = (noteId: number, goalId: number, callbacks?: { onErr
   });
 };
 
-export const useDeleteNote = (noteId: number, goalId: number, callbacks?: { onError?: (error: Error) => void }) => {
+export const useDeleteNote = (noteId: number, goalId: number) => {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const queryClient = useQueryClient();
+  const { showToast } = useToastStore();
 
   return useMutation({
     mutationFn: () => fetchNotes.deleteNote(noteId),
     onSuccess: () => {
+      showToast('노트가 삭제되었습니다.', 'success');
       queryClient.removeQueries({
         queryKey: noteQueries.detail(noteId).queryKey,
       });
@@ -398,10 +401,11 @@ export const useDeleteNote = (noteId: number, goalId: number, callbacks?: { onEr
         queryKey: noteKeys.lists(),
       });
 
-      router.push(`/goal/${goalId}/note`);
+      const page = searchParams.get('page') ?? '1';
+      router.push(`/goal/${goalId}/note?page=${page}`);
     },
-    onError: (error) => {
-      callbacks?.onError?.(error);
+    onError: () => {
+      showToast('노트 삭제에 실패했습니다', 'fail')
     },
   });
 };

--- a/src/shared/types/api/schemas/api.types.ts
+++ b/src/shared/types/api/schemas/api.types.ts
@@ -4,6 +4,22 @@
  */
 
 export interface paths {
+    "/api/v1/webhooks/github": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["receive"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/todos": {
         parameters: {
             query?: never;
@@ -46,6 +62,26 @@ export interface paths {
          * @description 할일에 연결된 노트를 생성합니다 (todoId in body)
          */
         post: operations["create_1"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/integrations/github/repositories/connect": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * GitHub 레포 연결
+         * @description 선택한 레포를 목표로 연결하고 webhook 및 초기 동기화를 수행합니다.
+         */
+        post: operations["connectRepository"];
         delete?: never;
         options?: never;
         head?: never;
@@ -580,6 +616,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/integrations/github/repositories": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * GitHub 레포 목록 조회
+         * @description GitHub 로그인으로 저장된 토큰으로 접근 가능한 레포 목록을 조회합니다.
+         */
+        get: operations["listRepositories"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/dev/auth/oauth/google/url": {
         parameters: {
             query?: never;
@@ -647,6 +703,26 @@ export interface paths {
         put?: never;
         post?: never;
         delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/integrations/github/goals/{goalId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * GitHub 레포 연결 해제
+         * @description 연결된 GitHub 목표의 webhook을 제거하고 목표를 soft delete 합니다.
+         */
+        delete: operations["disconnectRepository"];
         options?: never;
         head?: never;
         patch?: never;
@@ -851,25 +927,10 @@ export interface components {
             /** @description 태그 목록 */
             tags: components["schemas"]["TagInfo"][];
         };
-        /** @description 이미지 업로드 URL 발급 요청 */
-        ImageUploadRequest: {
-            /**
-             * @description 업로드할 파일명
-             * @example profile.png
-             */
-            fileName: string;
-        };
-        /** @description 이미지 업로드 URL 발급 응답 */
-        ImageUploadResponse: {
-            /** @description S3에 직접 업로드할 presigned URL */
-            uploadUrl: string;
-            /** @description 업로드 완료 후 저장될 공개 URL */
-            url: string;
-        };
-        /** @description 목표 생성 요청 */
-        CreateGoalRequest: {
-            /** @description 목표 제목 */
-            title: string;
+        /** @description GitHub 레포 연결 요청 */
+        ConnectGitHubRepositoryRequest: {
+            /** @description 레포 전체 이름 (owner/repo) */
+            repositoryFullName: string;
         };
         /** @description 목표 응답 */
         GoalResponse: {
@@ -917,6 +978,26 @@ export interface components {
              * @description 수정일시
              */
             updatedAt: string;
+        };
+        /** @description 이미지 업로드 URL 발급 요청 */
+        ImageUploadRequest: {
+            /**
+             * @description 업로드할 파일명
+             * @example profile.png
+             */
+            fileName: string;
+        };
+        /** @description 이미지 업로드 URL 발급 응답 */
+        ImageUploadResponse: {
+            /** @description S3에 직접 업로드할 presigned URL */
+            uploadUrl: string;
+            /** @description 업로드 완료 후 저장될 공개 URL */
+            url: string;
+        };
+        /** @description 목표 생성 요청 */
+        CreateGoalRequest: {
+            /** @description 목표 제목 */
+            title: string;
         };
         /** @description 회원가입 요청 */
         SignupRequest: {
@@ -1183,6 +1264,22 @@ export interface components {
              */
             totalPages: number;
         };
+        /** @description GitHub 레포 정보 */
+        GitHubRepositoryResponse: {
+            /**
+             * Format: int64
+             * @description 레포 ID
+             */
+            id: number;
+            /** @description 레포 이름 */
+            name: string;
+            /** @description 레포 전체 이름 (owner/repo) */
+            fullName: string;
+            /** @description 레포 URL */
+            htmlUrl: string;
+            /** @description private 여부 */
+            isPrivate: boolean;
+        };
         /** @description 목표 목록 응답 */
         GoalListResponse: {
             /** @description 목표 목록 */
@@ -1287,6 +1384,31 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    receive: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-GitHub-Event": string;
+                "X-Hub-Signature-256": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": string;
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     getList: {
         parameters: {
             query?: {
@@ -1408,6 +1530,39 @@ export interface operations {
             };
             /** @description 필수값 누락 / 존재하지 않는 할일 */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    connectRepository: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConnectGitHubRepositoryRequest"];
+            };
+        };
+        responses: {
+            /** @description 연결 성공 */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GoalResponse"];
+                };
+            };
+            /** @description 이미 연결된 레포 */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -2434,6 +2589,35 @@ export interface operations {
             };
         };
     };
+    listRepositories: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 조회 성공 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GitHubRepositoryResponse"][];
+                };
+            };
+            /** @description GitHub 로그인 필요 */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
     getGoogleAuthorizeUrl: {
         parameters: {
             query?: never;
@@ -2510,6 +2694,35 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["OAuthAuthorizeUrlResponse"];
+                };
+            };
+        };
+    };
+    disconnectRepository: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                goalId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 연결 해제 성공 */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description 목표를 찾을 수 없음 */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
         };


### PR DESCRIPTION
## 무엇을 변경했나요?
- 강사님 피드백 반영
  - [x] NoteCreateClient와 NoteEditClient의 중복 로직 해결
  - [x] Pagination Chevron 컴포넌트 중복
  - [x] NoteListClient 렌더 중 setState 호출
  - [x] NoteDetailClient에서 로딩/에러 상태 누락
  - [x] NoteItem 시맨틱 태그 정리

- 페이지네이션 수정 
  - 없는 페이지 노출 시 리디렉션 처리

- mutations의 onError 콜백 정리

## 왜 이렇게 했나요?
- 페이지네이션 수정 
-> 페이지네이션에 없는 페이지 번호가 생김. 캐시 문제 X, 백엔드 문제 X, 새 테스트에서 잘 작동하는 것으로 봐서는 개발 도중 API 수정으로 한 번 꼬인듯 했음. 앞으로도 이런 문제가 생길까 싶어서 방어 코드 추가

- mutations의 onError 콜백 정리
-> 다른 코드와 싱크 맞추기 + onError처리를 mutations에서 하는 게 더 깔끔

## 리뷰어가 특히 봐줬으면 하는 부분

## 스크린샷 (UI 변경 시)

Closes #96 
Closes #75 