### PR TITLE
feat: 캘린더 i18n 번역 충돌 해결

### DIFF
--- a/src/features/calendar/components/CalendarClient/index.tsx
+++ b/src/features/calendar/components/CalendarClient/index.tsx
@@ -44,8 +44,6 @@ export default function CalendarClient() {
       {!isMobile && <PageHeader title={user?.nickname ? `${user.nickname}${t.calendar.title}` : t.sidebar.calendar} className="md:mb-[32px] lg:mb-5" />}
       <div className="border-border-secondary flex w-full flex-col bg-white md:rounded-t-4xl md:rounded-b-4xl md:border">
         <CalendarHeader
-          year={year}
-          month={month}
           goalId={goalId}
           goalFilterItems={translatedGoalFilterItems}
           formattedYearMonth={formattedYearMonth}

--- a/src/features/calendar/components/CalendarClient/index.tsx
+++ b/src/features/calendar/components/CalendarClient/index.tsx
@@ -5,9 +5,10 @@ import CalendarHeader from '@/features/calendar/components/CalendarHeader';
 import CalendarDayTodoList from '@/features/calendar/components/CalendarDayTodoList';
 import PageHeader from '@/shared/components/PageHeader';
 import { useBreakpoint } from '@/shared/hooks/useBreakPoint';
-import Dropdown from '@/shared/components/Dropdown';
 import { useLanguage } from '@/shared/contexts/LanguageContext';
 import { useCalendar } from '@/features/calendar/hooks/useCalendar';
+
+const localeMap: Record<string, string> = { ko: 'ko-KR', en: 'en-US', ja: 'ja-JP', zh: 'zh-CN' };
 
 export default function CalendarClient() {
   const {
@@ -29,16 +30,25 @@ export default function CalendarClient() {
   const breakpoint = useBreakpoint();
   const isMobile = breakpoint === 'mobile';
   const isDesktop = breakpoint === 'desktop';
+  const { t, language } = useLanguage();
+
+  const formattedYearMonth = new Intl.DateTimeFormat(localeMap[language], { year: 'numeric', month: 'long' }).format(new Date(year, month - 1));
+
+  const translatedGoalFilterItems = [
+    { label: t.calendar.allGoal, value: '' },
+    ...goalFilterItems.filter((item) => item.value !== ''),
+  ];
 
   return (
     <>
-      {!isMobile && <PageHeader title={`${user?.nickname ?? ''}님의 캘린더`} className="md:mb-[32px] lg:mb-5" />}
+      {!isMobile && <PageHeader title={user?.nickname ? `${user.nickname}${t.calendar.title}` : t.sidebar.calendar} className="md:mb-[32px] lg:mb-5" />}
       <div className="border-border-secondary flex w-full flex-col bg-white md:rounded-t-4xl md:rounded-b-4xl md:border">
         <CalendarHeader
           year={year}
           month={month}
           goalId={goalId}
-          goalFilterItems={goalFilterItems}
+          goalFilterItems={translatedGoalFilterItems}
+          formattedYearMonth={formattedYearMonth}
           onPrev={prevMonth}
           onNext={nextMonth}
           onGoalChange={(item) => setGoalId(item.value === '' ? undefined : Number(item.value))}

--- a/src/features/calendar/components/CalendarHeader/index.tsx
+++ b/src/features/calendar/components/CalendarHeader/index.tsx
@@ -8,6 +8,7 @@ interface CalendarHeaderProps {
   month: number;
   goalId: number | undefined;
   goalFilterItems: DropdownItemType[];
+  formattedYearMonth: string;
   onPrev: () => void;
   onNext: () => void;
   onGoalChange: (item: DropdownItemType) => void;
@@ -18,6 +19,7 @@ export default function CalendarHeader({
   month,
   goalId,
   goalFilterItems,
+  formattedYearMonth,
   onPrev,
   onNext,
   onGoalChange,
@@ -29,7 +31,7 @@ export default function CalendarHeader({
           <ChevronsLeftIcon size={20} className="text-gray-500" />
         </button>
         <span className="text-lg font-semibold text-gray-800">
-          {year}년 {month}월
+          {formattedYearMonth}
         </span>
         <button onClick={onNext} className="cursor-pointer rounded-full p-1 hover:bg-gray-100">
           <ChevronsRightIcon size={20} className="text-gray-500" />

--- a/src/features/calendar/components/CalendarHeader/index.tsx
+++ b/src/features/calendar/components/CalendarHeader/index.tsx
@@ -4,8 +4,6 @@ import Image from 'next/image';
 import { DropdownItemType } from '@/shared/types/types';
 
 interface CalendarHeaderProps {
-  year: number;
-  month: number;
   goalId: number | undefined;
   goalFilterItems: DropdownItemType[];
   formattedYearMonth: string;
@@ -15,8 +13,6 @@ interface CalendarHeaderProps {
 }
 
 export default function CalendarHeader({
-  year,
-  month,
   goalId,
   goalFilterItems,
   formattedYearMonth,

--- a/src/shared/locales/en.json
+++ b/src/shared/locales/en.json
@@ -221,8 +221,6 @@
   },
   "calendar": {
     "title": "'s Calendar",
-    "allGoal": "All Goals",
-    "yearSuffix": "",
-    "monthSuffix": ""
+    "allGoal": "All Goals"
   }
 }

--- a/src/shared/locales/ja.json
+++ b/src/shared/locales/ja.json
@@ -221,8 +221,6 @@
   },
   "calendar": {
     "title": "さんのカレンダー",
-    "allGoal": "すべての目標",
-    "yearSuffix": "年",
-    "monthSuffix": "月"
+    "allGoal": "すべての目標"
   }
 }

--- a/src/shared/locales/ko.json
+++ b/src/shared/locales/ko.json
@@ -221,8 +221,6 @@
   },
   "calendar": {
     "title": "님의 캘린더",
-    "allGoal": "전체 목표",
-    "yearSuffix": "년",
-    "monthSuffix": "월"
+    "allGoal": "전체 목표"
   }
 }

--- a/src/shared/locales/zh.json
+++ b/src/shared/locales/zh.json
@@ -221,8 +221,6 @@
   },
   "calendar": {
     "title": "的日历",
-    "allGoal": "全部目标",
-    "yearSuffix": "年",
-    "monthSuffix": "月"
+    "allGoal": "全部目标"
   }
 }


### PR DESCRIPTION
## 무엇을 변경했나요?

캘린더 페이지 i18n 번역 충돌 해결 및 재적용

## 왜 이렇게 했나요?

머지 과정에서 번역 코드가 충돌나서 재적용

## 리뷰어가 특히 봐줬으면 하는 부분

- 언어 변경 시 캘린더 제목, 년/월, 전체 목표 번역 정상 동작 여부

## 스크린샷 (UI 변경 시)
