### PR TITLE
feat: 회원탈퇴 후 로그인 페이지로 리다이렉트

### DIFF
--- a/src/app/(main)/mypage/MyPageForm.tsx
+++ b/src/app/(main)/mypage/MyPageForm.tsx
@@ -116,12 +116,17 @@ export default function MyPageForm() {
         onConfirm={async (password) => {
           try {
             await fetchUsers.deleteCurrentUser(password ? { password } : undefined);
-            await fetch('/api/clear-session', { method: 'POST' });
-            router.push('/login');
           } catch (error) {
             console.error('Failed to delete account:', error);
             showToast(t.mypage.withdrawFail, 'fail');
+            return;
           }
+          try {
+            await fetch('/api/clear-session', { method: 'POST' });
+          } catch (e) {
+            console.error('Failed to clear session:', e);
+          }
+          router.push('/login');
         }}
       />,
     );

--- a/src/app/(main)/mypage/MyPageForm.tsx
+++ b/src/app/(main)/mypage/MyPageForm.tsx
@@ -116,6 +116,7 @@ export default function MyPageForm() {
         onConfirm={async (password) => {
           try {
             await fetchUsers.deleteCurrentUser(password ? { password } : undefined);
+            await fetch('/api/clear-session', { method: 'POST' });
             router.push('/login');
           } catch (error) {
             console.error('Failed to delete account:', error);

--- a/src/app/api/clear-session/route.ts
+++ b/src/app/api/clear-session/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  const response = NextResponse.json({ ok: true });
+  response.cookies.delete('accessToken');
+  response.cookies.delete('refreshToken');
+  return response;
+}


### PR DESCRIPTION
## 무엇을 변경했나요?

회원탈퇴 후 세션 쿠키를 초기화하는 API 라우트 추가 및 로그인 페이지로 리다이렉트 처리

## 왜 이렇게 했나요?

회원탈퇴 후 /login으로 이동해도 쿠키가 남아있어 /dashboard로 리다이렉트되는 버그 수정

## 리뷰어가 특히 봐줬으면 하는 부분

- [ ] (예: 이 로직이 엣지케이스를 잘 처리하는지)

## 스크린샷 (UI 변경 시)
