### PR TITLE
fix: 노트 제목 placeholder 색상 라이트/다크 공통 적용

### DIFF
--- a/src/features/note/components/NoteEditor/EditorTitle/index.tsx
+++ b/src/features/note/components/NoteEditor/EditorTitle/index.tsx
@@ -23,7 +23,7 @@ export default function EditorTitle({ title, onChange, readOnly = false }: Edito
         maxLength={30}
         placeholder={t.note.titlePlaceholder}
         className={clsx(
-          'min-w-0 flex-1 border-none p-0 text-left text-slate-700 dark:text-white dark:placeholder:text-[#BBBBBB] outline-none',
+          'min-w-0 flex-1 border-none p-0 text-left text-slate-700 dark:text-white placeholder:text-[#BBBBBB] outline-none',
           'text-base font-semibold',
           'md:text-2xl md:font-semibold',
           readOnly && 'cursor-default',

--- a/src/features/note/components/NoteEditor/EditorTitle/index.tsx
+++ b/src/features/note/components/NoteEditor/EditorTitle/index.tsx
@@ -23,7 +23,7 @@ export default function EditorTitle({ title, onChange, readOnly = false }: Edito
         maxLength={30}
         placeholder={t.note.titlePlaceholder}
         className={clsx(
-          'min-w-0 flex-1 border-none p-0 text-left text-slate-700 dark:text-white placeholder:text-[#BBBBBB] outline-none',
+          'w-full border-none p-0 text-left text-slate-700 dark:text-white placeholder:text-text-muted outline-none',
           'text-base font-semibold',
           'md:text-2xl md:font-semibold',
           readOnly && 'cursor-default',


### PR DESCRIPTION
## 무엇을 변경했나요?

노트 제목 placeholder 색상 라이트/다크 공통 적용

## 왜 이렇게 했나요?

(선택한 이유, 다른 방법 대신 이걸 선택한 이유)

## 리뷰어가 특히 봐줬으면 하는 부분

- [ ] (예: 이 로직이 엣지케이스를 잘 처리하는지)

## 스크린샷 (UI 변경 시)
