### PR TITLE
fix: 로그인/회원가입 버튼 텍스트 색상 및 비밀번호 아이콘 정렬 수정

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -98,7 +98,7 @@ export default function LoginPage() {
               onChange={(e) => setPassword(e.target.value)}
             />
           </FormField>
-          <Button type="submit" className="mt-8 h-14 w-full text-[#2F2F2F]" disabled={!email || !password || isLoading}>
+          <Button type="submit" className="mt-8 h-14 w-full text-white" disabled={!email || !password || isLoading}>
             {isLoading ? <LoadingSpinner /> : t.auth.loginButton}
           </Button>
         </form>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -98,7 +98,7 @@ export default function LoginPage() {
               onChange={(e) => setPassword(e.target.value)}
             />
           </FormField>
-          <Button type="submit" className="mt-8 h-14 w-full text-white" disabled={!email || !password || isLoading}>
+          <Button type="submit" className="mt-8 h-14 w-full" disabled={!email || !password || isLoading}>
             {isLoading ? <LoadingSpinner /> : t.auth.loginButton}
           </Button>
         </form>

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -133,7 +133,7 @@ export default function SignupPage() {
 
           <Button
             type="submit"
-            className="mt-8 h-14 w-full text-white"
+            className="mt-8 h-14 w-full"
             disabled={!isValid || isSubmitting}
           >
             {isSubmitting ? <LoadingSpinner /> : t.auth.signupButton}

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -133,7 +133,7 @@ export default function SignupPage() {
 
           <Button
             type="submit"
-            className="mt-8 h-14 w-full text-gray-850"
+            className="mt-8 h-14 w-full text-white"
             disabled={!isValid || isSubmitting}
           >
             {isSubmitting ? <LoadingSpinner /> : t.auth.signupButton}

--- a/src/shared/components/Input/index.tsx
+++ b/src/shared/components/Input/index.tsx
@@ -42,7 +42,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           <button
             type="button"
             onClick={() => setShowPassword(!showPassword)}
-            className="absolute top-[60%] right-5 -translate-y-1/2 text-gray-500"
+            className="absolute top-1/2 right-5 -translate-y-1/2 text-gray-500"
             aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
           >
             {showPassword ? <Eye size={22} /> : <EyeOff size={22} />}


### PR DESCRIPTION
## 무엇을 변경했나요?

- 로그인/회원가입 버튼 텍스트 색상을 흰색으로 변경
- 비밀번호 입력 필드 눈 아이콘 세로 정렬 수정

## 왜 이렇게 했나요?

(선택한 이유, 다른 방법 대신 이걸 선택한 이유)

## 리뷰어가 특히 봐줬으면 하는 부분

- [ ] (예: 이 로직이 엣지케이스를 잘 처리하는지)

## 스크린샷 (UI 변경 시)
