### PR TITLE
[fix/notepage-bug] 노트 페이지 버그 수정

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,14 +10,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
-      - uses: pnpm/action-setup@v4
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(pnpm exec playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps
       - name: Run Playwright tests
         run: pnpm exec playwright test
         env:

--- a/src/app/(main)/goal/[goalId]/note/@modal/page.tsx
+++ b/src/app/(main)/goal/[goalId]/note/@modal/page.tsx
@@ -1,0 +1,3 @@
+export default function ModalPage() {
+  return null;
+}

--- a/src/app/(main)/goal/[goalId]/note/[noteId]/(detail)/layout.tsx
+++ b/src/app/(main)/goal/[goalId]/note/[noteId]/(detail)/layout.tsx
@@ -9,13 +9,13 @@ export default function NoteDetailLayout({ children }: { children: React.ReactNo
   const { goalId } = useParams<{ goalId: string }>();
 
   const handleClose = () => {
-    router.push('/goal/' + goalId + '/note');
+    router.replace('/goal/' + goalId + '/note');
   };
 
   return (
     <div className={clsx('fixed inset-0 z-50 overflow-y-auto bg-white dark:bg-gray-850')}>
       {children}
-      <NoteCloseButton onClose={handleClose} />
+      <NoteCloseButton onCloseAction={handleClose} />
     </div>
   );
 }

--- a/src/app/(main)/goal/[goalId]/note/[noteId]/(detail)/layout.tsx
+++ b/src/app/(main)/goal/[goalId]/note/[noteId]/(detail)/layout.tsx
@@ -9,7 +9,7 @@ export default function NoteDetailLayout({ children }: { children: React.ReactNo
   const { goalId } = useParams<{ goalId: string }>();
 
   const handleClose = () => {
-    router.replace('/goal/' + goalId + '/note');
+    router.replace(`/goal/${goalId}/note`);
   };
 
   return (

--- a/src/features/note/components/NoteDetailModal/index.tsx
+++ b/src/features/note/components/NoteDetailModal/index.tsx
@@ -23,7 +23,7 @@ export default function NoteDetailModal({ children }: { children: React.ReactNod
 
   const handleClose = () => {
     setClosing(true);
-    setTimeout(() => router.push(`/goal/${goalId}/note`), ANIMATION_DURATION);
+    setTimeout(() => router.replace(`/goal/${goalId}/note`), ANIMATION_DURATION);
   };
 
   return (
@@ -31,13 +31,13 @@ export default function NoteDetailModal({ children }: { children: React.ReactNod
       <Backdrop onClick={handleClose} closing={closing} />
       <div
         className={clsx(
-          'fixed inset-y-0 right-0 z-50 w-full overflow-y-auto bg-white dark:bg-gray-850',
+          'dark:bg-gray-850 fixed inset-y-0 right-0 z-50 w-full overflow-y-auto bg-white',
           'lg:w-[744px] lg:rounded-l-[40px]',
           closing ? 'note-panel-exit' : 'note-panel-enter',
         )}
       >
         {children}
-        <NoteCloseButton onClose={handleClose} />
+        <NoteCloseButton onCloseAction={handleClose} />
       </div>
     </>
   );

--- a/src/features/note/components/NoteEditor/EditorTitle/NoteCloseButton/index.tsx
+++ b/src/features/note/components/NoteEditor/EditorTitle/NoteCloseButton/index.tsx
@@ -2,9 +2,13 @@
 
 import { XIcon } from 'lucide-react';
 
-export default function NoteCloseButton({ onClose }: { onClose: () => void }) {
+export default function NoteCloseButton({ onCloseAction }: { onCloseAction: () => void }) {
   return (
-    <button type="button" onClick={onClose} className="absolute top-5 right-5 cursor-pointer md:top-10 md:right-10">
+    <button
+      type="button"
+      onClick={onCloseAction}
+      className="absolute top-5 right-5 cursor-pointer md:top-10 md:right-10"
+    >
       <XIcon size={24} className="stroke-[#A4A4A4]" />
     </button>
   );

--- a/src/shared/lib/query/mutations.ts
+++ b/src/shared/lib/query/mutations.ts
@@ -620,7 +620,7 @@ export const usePostNote = () => {
         queryKey: noteKeys.lists(),
       });
 
-      router.push(`/goal/${response.goalId}/note/${response.id}`);
+      router.replace(`/goal/${response.goalId}/note/${response.id}`);
     },
     onError: () => {
       showToast(t.mutations.noteCreateFail, 'fail');

--- a/src/shared/lib/query/mutations.ts
+++ b/src/shared/lib/query/mutations.ts
@@ -638,7 +638,7 @@ export const usePatchNote = (noteId: number, goalId: number) => {
     onSuccess: (response) => {
       queryClient.setQueryData(noteQueries.detail(noteId).queryKey, response);
       queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
-      router.push(`/goal/${goalId}/note/${noteId}`);
+      router.replace(`/goal/${goalId}/note/${noteId}`);
     },
     onError: () => showToast(t.mutations.noteUpdateFail, 'fail'),
   });
@@ -663,7 +663,7 @@ export const useDeleteNote = (noteId: number, goalId: number) => {
       });
 
       const page = searchParams.get('page') ?? '1';
-      router.push(`/goal/${goalId}/note?page=${page}`);
+      router.replace(`/goal/${goalId}/note?page=${page}`);
     },
     onError: () => {
       showToast(t.mutations.noteDeleteFail, 'fail');


### PR DESCRIPTION
## 무엇을 변경했나요?
- 노트 생성/수정 시 노트 상세 페이지로 리다이렉트 후 노트 목록으로 이동하면 노트 목록 페이지가 동작하지 않는 버그가 있어 수정 
  - 생성/수정 후 + modal 닫을 때 router.push -> replace로 수정
  - @modal에 기본 페이지 추가

## 왜 이렇게 했나요?
- 노트 생성/수정 후 이동 및 모달 닫기에 push 대신 replace를 사용한 이유: push는 히스토리를 남겨 뒤로가기 시 닫힌 모달이나 작성/수정 화면으로 다시 돌아갈 수 있어, 현재 경로를 교체하는 replace가 더 적합하다고 판단
- 기본 페이지 추가한 이유: 기존에는 fallback 페이지밖에 없었어서 오류가 난 것

## 리뷰어가 특히 봐줬으면 하는 부분

- [ ] (예: 이 로직이 엣지케이스를 잘 처리하는지)

## 스크린샷 (UI 변경 시)
